### PR TITLE
Add instance-properties group to sort-comp. Issue #599.

### DIFF
--- a/docs/rules/sort-comp.md
+++ b/docs/rules/sort-comp.md
@@ -9,9 +9,10 @@ When creating React components it is more convenient to always follow the same o
 With default configuration the following organisation must be followed:
 
   1. static methods and properties
-  2. lifecycle methods: `displayName`, `propTypes`, `contextTypes`, `childContextTypes`, `mixins`, `statics`,`defaultProps`, `constructor`, `getDefaultProps`, `getInitialState`, `state`, `getChildContext`, `componentWillMount`, `componentDidMount`, `componentWillReceiveProps`, `shouldComponentUpdate`, `componentWillUpdate`, `componentDidUpdate`, `componentWillUnmount` (in this order).
-  3. custom methods
-  4. `render` method
+  2. instance properties
+  3. lifecycle methods: `displayName`, `propTypes`, `contextTypes`, `childContextTypes`, `mixins`, `statics`,`defaultProps`, `constructor`, `getDefaultProps`, `getInitialState`, `state`, `getChildContext`, `componentWillMount`, `componentDidMount`, `componentWillReceiveProps`, `shouldComponentUpdate`, `componentWillUpdate`, `componentDidUpdate`, `componentWillUnmount` (in this order).
+  4. custom methods
+  5. `render` method
 
 The following patterns are considered warnings:
 
@@ -55,6 +56,7 @@ The default configuration is:
 {
   order: [
     'static-methods',
+    'instance-properties',
     'lifecycle',
     'everything-else',
     'render'
@@ -86,6 +88,7 @@ The default configuration is:
 ```
 
 * `static-methods` is a special keyword that refers to static class methods.
+* `instance-properties` is a special keyword that refers to class instance properties.
 * `lifecycle` is referring to the `lifecycle` group defined in `groups`.
 * `everything-else` is a special group that match all the methods that do not match any of the other groups.
 * `render` is referring to the `render` method.
@@ -98,6 +101,7 @@ For example, if you want to place your event handlers (`onClick`, `onSubmit`, et
 "react/sort-comp": [1, {
   order: [
     'static-methods',
+    'instance-properties',
     'lifecycle',
     '/^on.+$/',
     'render',
@@ -134,6 +138,7 @@ If you want to split your `render` method into smaller ones and keep them just b
 "react/sort-comp": [1, {
   order: [
     'static-methods',
+    'instance-properties',
     'lifecycle',
     'everything-else',
     'rendering',

--- a/lib/rules/sort-comp.js
+++ b/lib/rules/sort-comp.js
@@ -47,6 +47,7 @@ module.exports = Components.detect(function(context, components) {
   var methodsOrder = getMethodsOrder({
     order: [
       'static-methods',
+      'instance-properties',
       'lifecycle',
       'everything-else',
       'render'
@@ -97,6 +98,15 @@ module.exports = Components.detect(function(context, components) {
     if (method.static) {
       for (i = 0, j = methodsOrder.length; i < j; i++) {
         if (methodsOrder[i] === 'static-methods') {
+          indexes.push(i);
+          break;
+        }
+      }
+    }
+
+    if (method.instanceProperty) {
+      for (i = 0, j = methodsOrder.length; i < j; i++) {
+        if (methodsOrder[i] === 'instance-properties') {
           indexes.push(i);
           break;
         }
@@ -320,7 +330,10 @@ module.exports = Components.detect(function(context, components) {
     var propertiesInfos = properties.map(function(node) {
       return {
         name: getPropertyName(node),
-        static: node.static
+        static: node.static,
+        instanceProperty: !node.static &&
+          (node.type === 'ClassProperty') &&
+          (node.value.type !== 'ArrowFunctionExpression')
       };
     });
 

--- a/lib/rules/sort-comp.js
+++ b/lib/rules/sort-comp.js
@@ -333,7 +333,7 @@ module.exports = Components.detect(function(context, components) {
         static: node.static,
         instanceProperty: !node.static &&
           (node.type === 'ClassProperty') &&
-          (node.value.type !== 'ArrowFunctionExpression')
+          (!node.value || node.value.type !== 'ArrowFunctionExpression')
       };
     });
 

--- a/lib/rules/sort-comp.js
+++ b/lib/rules/sort-comp.js
@@ -47,7 +47,6 @@ module.exports = Components.detect(function(context, components) {
   var methodsOrder = getMethodsOrder({
     order: [
       'static-methods',
-      'instance-properties',
       'lifecycle',
       'everything-else',
       'render'

--- a/tests/lib/rules/sort-comp.js
+++ b/tests/lib/rules/sort-comp.js
@@ -273,5 +273,32 @@ ruleTester.run('sort-comp', rule, {
     parser: 'babel-eslint',
     parserOptions: parserOptions,
     errors: [{message: 'render should be placed after displayName'}]
+  }, {
+    // Must validate instance properties
+    code: [
+      'class Hello extends React.Component {',
+      '  render() {',
+      '    return <div></div>',
+      '  }',
+      '  count = 2;',
+      '}'
+    ].join('\n'),
+    parser: 'babel-eslint',
+    parserOptions: parserOptions,
+    errors: [{message: 'render should be placed after count'}]
+  }, {
+    // Must differentiate between instance and static properties
+    code: [
+      'class Hello extends React.Component {',
+      '  count = 2;',
+      '  static displayName = \'Hello\';',
+      '  render() {',
+      '    return <div></div>',
+      '  }',
+      '}'
+    ].join('\n'),
+    parser: 'babel-eslint',
+    parserOptions: parserOptions,
+    errors: [{message: 'count should be placed after displayName'}]
   }]
 });

--- a/tests/lib/rules/sort-comp.js
+++ b/tests/lib/rules/sort-comp.js
@@ -306,7 +306,8 @@ ruleTester.run('sort-comp', rule, {
     parserOptions: parserOptions,
     errors: [{message: 'render should be placed after displayName'}]
   }, {
-    // Must validate instance properties if found if configuration
+    // Must validate instance properties
+    // if `instance-properties` is found in configuration
     code: [
       'class Hello extends React.Component {',
       '  render() {',
@@ -325,7 +326,7 @@ ruleTester.run('sort-comp', rule, {
     parserOptions: parserOptions,
     errors: [{message: 'render should be placed after count'}]
   }, {
-    // Must differentiate between instance and static properties,
+    // Must differentiate between instance and static properties
     // if `instance-properties` is found in configuration
     code: [
       'class Hello extends React.Component {',

--- a/tests/lib/rules/sort-comp.js
+++ b/tests/lib/rules/sort-comp.js
@@ -204,6 +204,20 @@ ruleTester.run('sort-comp', rule, {
     ].join('\n'),
     parser: 'babel-eslint'
   }, {
+    // Must consider `instance-properties` part of `everything-else` by default
+    code: [
+      'class Hello extends React.Component {',
+      '  static displayName = \'Hello\';',
+      '  componentDidMount() {}',
+      '  count = 5;',
+      '  render() {',
+      '    return <div>Hello</div>;',
+      '  }',
+      '}'
+    ].join('\n'),
+    parser: 'babel-eslint',
+    parserOptions: parserOptions
+  }, {
     // Must allow non-initialized instance properties
     code: [
       'class Hello extends React.Component {',
@@ -214,6 +228,12 @@ ruleTester.run('sort-comp', rule, {
       '}'
     ].join('\n'),
     parser: 'babel-eslint',
+    options: [{
+      order: [
+        'instance-properties',
+        'render'
+      ]
+    }],
     parserOptions: parserOptions
   }],
 
@@ -286,7 +306,7 @@ ruleTester.run('sort-comp', rule, {
     parserOptions: parserOptions,
     errors: [{message: 'render should be placed after displayName'}]
   }, {
-    // Must validate instance properties
+    // Must validate instance properties if found if configuration
     code: [
       'class Hello extends React.Component {',
       '  render() {',
@@ -296,10 +316,17 @@ ruleTester.run('sort-comp', rule, {
       '}'
     ].join('\n'),
     parser: 'babel-eslint',
+    options: [{
+      order: [
+        'instance-properties',
+        'render'
+      ]
+    }],
     parserOptions: parserOptions,
     errors: [{message: 'render should be placed after count'}]
   }, {
-    // Must differentiate between instance and static properties
+    // Must differentiate between instance and static properties,
+    // if `instance-properties` is found in configuration
     code: [
       'class Hello extends React.Component {',
       '  count = 2;',
@@ -310,7 +337,36 @@ ruleTester.run('sort-comp', rule, {
       '}'
     ].join('\n'),
     parser: 'babel-eslint',
+    options: [{
+      order: [
+        'static-methods',
+        'instance-properties',
+        'render'
+      ]
+    }],
     parserOptions: parserOptions,
     errors: [{message: 'count should be placed after displayName'}]
+  }, {
+    // Must differentiate between `instance-properties` and instance arrow functions
+    // if `instance-properties` is found in configuration
+    code: [
+      'class Hello extends React.Component {',
+      '  handleClick = () => {}',
+      '  count = 2;',
+      '  render() {',
+      '    return <div></div>',
+      '  }',
+      '}'
+    ].join('\n'),
+    parser: 'babel-eslint',
+    options: [{
+      order: [
+        'instance-properties',
+        'everything-else',
+        'render'
+      ]
+    }],
+    parserOptions: parserOptions,
+    errors: [{message: 'handleClick should be placed after count'}]
   }]
 });

--- a/tests/lib/rules/sort-comp.js
+++ b/tests/lib/rules/sort-comp.js
@@ -203,6 +203,18 @@ ruleTester.run('sort-comp', rule, {
       '});'
     ].join('\n'),
     parser: 'babel-eslint'
+  }, {
+    // Must allow non-initialized instance properties
+    code: [
+      'class Hello extends React.Component {',
+      '  count;',
+      '  render() {',
+      '    return <div>Hello</div>;',
+      '  }',
+      '}'
+    ].join('\n'),
+    parser: 'babel-eslint',
+    parserOptions: parserOptions
   }],
 
   invalid: [{


### PR DESCRIPTION
Relevant issue: https://github.com/yannickcr/eslint-plugin-react/issues/599

It's a common convention to have instance properties on top(right below the static properties/methods), like this:

``` js
class Hello extends React.Component {
  static displayName = 'Hello';

  count = 0;

  componentDidMount() {
    // ...
  }

  handleClick = () => {
    this.count += 1;
    // ...
  }

  render() {
    // ...
  }
}
```

Right now `sort-comp` rule doesn't allow that and wants `count` to be below `componentDidMount`, unless you specify it by name in the configuration.

This PR's aim is to allow placing instance properties separately.

The default configuration is not changed.
