### PR TITLE
Ignore jsx-key if inside React.Children.toArray()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 ### Fixed
 * [`no-unknown-property`]: add `dialog` attributes ([#3436][] @ljharb)
 * [`no-arrow-function-lifecycle`]: when converting from an arrow, remove the semi and wrapping parens ([#3337][] @ljharb)
+* [`jsx-key`]: Ignore elements inside `React.Children.toArray()` ([#1591][] @silvenon)
 
 [#3436]: https://github.com/jsx-eslint/eslint-plugin-react/issues/3436
 [#3337]: https://github.com/jsx-eslint/eslint-plugin-react/issues/3337
+[#1591]: https://github.com/jsx-eslint/eslint-plugin-react/pull/1591
 
 ## [7.31.8] - 2022.09.08
 

--- a/lib/rules/jsx-key.js
+++ b/lib/rules/jsx-key.js
@@ -155,10 +155,33 @@ module.exports = {
       }
     }
 
+    const childrenToArraySelector = `:matches(
+      CallExpression
+        [callee.object.object.name=${reactPragma}]
+        [callee.object.property.name=Children]
+        [callee.property.name=toArray],
+      CallExpression
+        [callee.object.name=Children]
+        [callee.property.name=toArray]
+    )`.replace(/\s/g, '');
+    let isWithinChildrenToArray = false;
+
     const seen = new WeakSet();
 
     return {
+      [childrenToArraySelector]() {
+        isWithinChildrenToArray = true;
+      },
+
+      [`${childrenToArraySelector}:exit`]() {
+        isWithinChildrenToArray = false;
+      },
+
       'ArrayExpression, JSXElement > JSXElement'(node) {
+        if (isWithinChildrenToArray) {
+          return;
+        }
+
         const jsx = (node.type === 'ArrayExpression' ? node.elements : node.parent.children).filter((x) => x && x.type === 'JSXElement');
         if (jsx.length === 0) {
           return;
@@ -205,7 +228,7 @@ module.exports = {
       },
 
       JSXFragment(node) {
-        if (!checkFragmentShorthand) {
+        if (!checkFragmentShorthand || isWithinChildrenToArray) {
           return;
         }
 
@@ -226,6 +249,10 @@ module.exports = {
        CallExpression[callee.type="OptionalMemberExpression"][callee.property.name="map"],\
        OptionalCallExpression[callee.type="MemberExpression"][callee.property.name="map"],\
        OptionalCallExpression[callee.type="OptionalMemberExpression"][callee.property.name="map"]'(node) {
+        if (isWithinChildrenToArray) {
+          return;
+        }
+
         const fn = node.arguments.length > 0 && node.arguments[0];
         if (!fn || !astUtil.isFunctionLikeExpression(fn)) {
           return;
@@ -238,6 +265,10 @@ module.exports = {
 
       // Array.from
       'CallExpression[callee.type="MemberExpression"][callee.property.name="from"]'(node) {
+        if (isWithinChildrenToArray) {
+          return;
+        }
+
         const fn = node.arguments.length > 1 && node.arguments[1];
         if (!astUtil.isFunctionLikeExpression(fn)) {
           return;

--- a/tests/lib/rules/jsx-key.js
+++ b/tests/lib/rules/jsx-key.js
@@ -176,6 +176,33 @@ ruleTester.run('jsx-key', rule, {
       `,
       features: ['types', 'no-babel-old'],
     },
+    { code: 'React.Children.toArray([1, 2 ,3].map(x => <App />));' },
+    {
+      code: `
+        import { Children } from "react";
+        Children.toArray([1, 2 ,3].map(x => <App />));
+      `,
+    },
+    {
+      // TODO: uncomment the commented lines below
+      code: `
+        import Act from 'react';
+        import { Children as ReactChildren } from 'react';
+        
+        const { Children } = Act;
+        const { toArray } = Children;
+        
+        Act.Children.toArray([1, 2 ,3].map(x => <App />));
+        Act.Children.toArray(Array.from([1, 2 ,3], x => <App />));
+        Children.toArray([1, 2 ,3].map(x => <App />));
+        Children.toArray(Array.from([1, 2 ,3], x => <App />));
+        // ReactChildren.toArray([1, 2 ,3].map(x => <App />));
+        // ReactChildren.toArray(Array.from([1, 2 ,3], x => <App />));
+        // toArray([1, 2 ,3].map(x => <App />));
+        // toArray(Array.from([1, 2 ,3], x => <App />));
+      `,
+      settings,
+    },
   ]),
   invalid: parsers.all([
     {


### PR DESCRIPTION
`jsx-key` rule should always succeed if we're inside `React.Children.toArray()` because omitting `key` there doesn't cause a React warning.

Fixes #1574.