### PR TITLE
fix: remove unnecessary schema from jsx-no-comment-textnodes

### DIFF
--- a/lib/rules/jsx-no-comment-textnodes.js
+++ b/lib/rules/jsx-no-comment-textnodes.js
@@ -20,11 +20,7 @@ module.exports = {
       url: docsUrl('jsx-no-comment-textnodes')
     },
 
-    schema: [{
-      type: 'object',
-      properties: {},
-      additionalProperties: false
-    }]
+    schema: []
   },
 
   create(context) {


### PR DESCRIPTION
I noticed that there was a schema defining an empty object - it's an unnecessary definition, so remove it.