### PR TITLE
fix: remove unnecessary schema from require-render-return

### DIFF
--- a/lib/rules/require-render-return.js
+++ b/lib/rules/require-render-return.js
@@ -21,7 +21,7 @@ module.exports = {
       recommended: true,
       url: docsUrl('require-render-return')
     },
-    schema: [{}]
+    schema: []
   },
 
   create: Components.detect((context, components, utils) => {


### PR DESCRIPTION
I noticed that there was a schema defining an empty object - it's an unnecessary definition, so remove it.