### PR TITLE
Fix edge cases on jsx-pascal-case

### DIFF
--- a/tests/lib/rules/jsx-pascal-case.js
+++ b/tests/lib/rules/jsx-pascal-case.js
@@ -66,17 +66,32 @@ ruleTester.run('jsx-pascal-case', rule, {
   }, {
     code: '<qualification.T3StComp0Nent />'
   }, {
+    code: '<__this.TestComponent />'
+  }, {
     code: '<Modal:Header />'
   }, {
-    code: '<IGNORED />',
-    options: [{ignore: ['IGNORED']}]
+    code: '<layout:Header />'
+  }, {
+    code: '<__ns:TestComponent />'
   }, {
     code: '<$ />'
   }, {
     code: '<_ />'
+  }, {
+    code: '<div />'
+  }, {
+    code: '<svg:path />'
+  }, {
+    code: '<foo.bar />'
+  }, {
+    code: '<IGNORED />',
+    options: [{ignore: ['IGNORED']}]
   }],
 
   invalid: [{
+    code: '<testComponent />',
+    errors: [{message: 'Imported JSX component testComponent must be in PascalCase'}]
+  }, {
     code: '<Test_component />',
     errors: [{message: 'Imported JSX component Test_component must be in PascalCase'}]
   }, {
@@ -85,6 +100,27 @@ ruleTester.run('jsx-pascal-case', rule, {
   }, {
     code: '<YMCA />',
     errors: [{message: 'Imported JSX component YMCA must be in PascalCase'}]
+  }, {
+    code: '<$a />',
+    errors: [{message: 'Imported JSX component $a must be in PascalCase'}]
+  }, {
+    code: '<object.testComponent />',
+    errors: [{message: 'Imported JSX component testComponent must be in PascalCase'}]
+  }, {
+    code: '<Module.testComponent />',
+    errors: [{message: 'Imported JSX component testComponent must be in PascalCase'}]
+  }, {
+    code: '<__this.testComponent />',
+    errors: [{message: 'Imported JSX component testComponent must be in PascalCase'}]
+  }, {
+    code: '<ns:testComponent />',
+    errors: [{message: 'Imported JSX component ns:testComponent must be in PascalCase'}]
+  }, {
+    code: '<Ns:testComponent />',
+    errors: [{message: 'Imported JSX component _Ns:testComponent must be in PascalCase'}]
+  }, {
+    code: '<__ns:testComponent />',
+    errors: [{message: 'Imported JSX component __ns:testComponent must be in PascalCase'}]
   }, {
     code: '<_TEST_COMPONENT />',
     options: [{allowAllCaps: true}],
@@ -97,8 +133,5 @@ ruleTester.run('jsx-pascal-case', rule, {
     code: '<__ />',
     options: [{allowAllCaps: true}],
     errors: [{message: 'Imported JSX component __ must be in PascalCase or SCREAMING_SNAKE_CASE'}]
-  }, {
-    code: '<$a />',
-    errors: [{message: 'Imported JSX component $a must be in PascalCase'}]
   }]
 });

--- a/tests/lib/rules/jsx-pascal-case.js
+++ b/tests/lib/rules/jsx-pascal-case.js
@@ -68,17 +68,23 @@ ruleTester.run('jsx-pascal-case', rule, {
   }, {
     code: '<__this.TestComponent />'
   }, {
-    code: '<Modal:Header />'
-  }, {
-    code: '<layout:Header />'
-  }, {
-    code: '<__ns:TestComponent />'
-  }, {
     code: '<$ />'
   }, {
     code: '<_ />'
   }, {
     code: '<div />'
+  }, {
+    code: '<svg:path />'
+  }, {
+    code: '<ns:testComponent />'
+  }, {
+    code: '<Ns:testComponent />'
+  }, {
+    code: '<Modal:Header />'
+  }, {
+    code: '<layout:Header />'
+  }, {
+    code: '<__ns:testComponent />'
   }, {
     code: '<IGNORED />',
     options: [{ignore: ['IGNORED']}]
@@ -111,18 +117,6 @@ ruleTester.run('jsx-pascal-case', rule, {
   }, {
     code: '<__this.testComponent />',
     errors: [{message: 'Imported JSX component testComponent must be in PascalCase'}]
-  }, {
-    code: '<svg:path />',
-    errors: [{message: 'Imported JSX component svg:path must be in PascalCase'}]
-  }, {
-    code: '<ns:testComponent />',
-    errors: [{message: 'Imported JSX component ns:testComponent must be in PascalCase'}]
-  }, {
-    code: '<Ns:testComponent />',
-    errors: [{message: 'Imported JSX component Ns:testComponent must be in PascalCase'}]
-  }, {
-    code: '<__ns:testComponent />',
-    errors: [{message: 'Imported JSX component __ns:testComponent must be in PascalCase'}]
   }, {
     code: '<_TEST_COMPONENT />',
     options: [{allowAllCaps: true}],

--- a/tests/lib/rules/jsx-pascal-case.js
+++ b/tests/lib/rules/jsx-pascal-case.js
@@ -80,10 +80,6 @@ ruleTester.run('jsx-pascal-case', rule, {
   }, {
     code: '<div />'
   }, {
-    code: '<svg:path />'
-  }, {
-    code: '<foo.bar />'
-  }, {
     code: '<IGNORED />',
     options: [{ignore: ['IGNORED']}]
   }],
@@ -104,6 +100,9 @@ ruleTester.run('jsx-pascal-case', rule, {
     code: '<$a />',
     errors: [{message: 'Imported JSX component $a must be in PascalCase'}]
   }, {
+    code: '<foo.bar />',
+    errors: [{message: 'Imported JSX component bar must be in PascalCase'}]
+  }, {
     code: '<object.testComponent />',
     errors: [{message: 'Imported JSX component testComponent must be in PascalCase'}]
   }, {
@@ -113,11 +112,14 @@ ruleTester.run('jsx-pascal-case', rule, {
     code: '<__this.testComponent />',
     errors: [{message: 'Imported JSX component testComponent must be in PascalCase'}]
   }, {
+    code: '<svg:path />',
+    errors: [{message: 'Imported JSX component svg:path must be in PascalCase'}]
+  }, {
     code: '<ns:testComponent />',
     errors: [{message: 'Imported JSX component ns:testComponent must be in PascalCase'}]
   }, {
     code: '<Ns:testComponent />',
-    errors: [{message: 'Imported JSX component _Ns:testComponent must be in PascalCase'}]
+    errors: [{message: 'Imported JSX component Ns:testComponent must be in PascalCase'}]
   }, {
     code: '<__ns:testComponent />',
     errors: [{message: 'Imported JSX component __ns:testComponent must be in PascalCase'}]

--- a/tests/lib/rules/jsx-pascal-case.js
+++ b/tests/lib/rules/jsx-pascal-case.js
@@ -78,28 +78,31 @@ ruleTester.run('jsx-pascal-case', rule, {
   }, {
     code: '<_ />'
   }, {
-    code: '<div />'
-  }, {
+    // The rule must not warn on components with a namespace
+    // because this pattern is handled by jsx-no-namespace
     code: '<svg:path />'
   }, {
     code: '<ns:testComponent />'
   }, {
     code: '<Ns:testComponent />'
   }, {
+    code: '<__ns:testComponent />'
+  }, {
+    code: '<ns:TestComponent />'
+  }, {
+    code: '<Ns:TestComponent />'
+  }, {
+    code: '<__ns:TestComponent />'
+  }, {
     code: '<Modal:Header />'
   }, {
     code: '<layout:Header />'
-  }, {
-    code: '<__ns:testComponent />'
   }, {
     code: '<IGNORED />',
     options: [{ignore: ['IGNORED']}]
   }],
 
   invalid: [{
-    code: '<testComponent />',
-    errors: [{message: 'Imported JSX component testComponent must be in PascalCase'}]
-  }, {
     code: '<Test_component />',
     errors: [{message: 'Imported JSX component Test_component must be in PascalCase'}]
   }, {


### PR DESCRIPTION
Currently the rule `jsx-pascal-case` doesn't support some edge cases:
- It improperly errors when the component is in a namespace that starts with an underscore
- It improperly succeeds on the component is in camelCase
- It improperly succeeds in a bunch of cases where the component is in a namespace
- It doesn't accurately report the name of the component in some error cases

The PR should fix #1334 