### PR TITLE
[new] Add no-update-forcing-props rule

### DIFF
--- a/docs/rules/jsx-no-update-forcing-props.md
+++ b/docs/rules/jsx-no-update-forcing-props.md
@@ -1,0 +1,96 @@
+# Prevent setting a prop that would force component to update (react/jsx-no-update-forcing-props)
+
+Warns you if you have passed a prop with a value that will be [referentially unequal](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Comparison_Operators#Identity_strict_equality_()) on each render. This is bad for performance, as it will result in the garbage collector being invoked way more than is necessary. It may also cause unnecessary re-renders if a brand new object or function is passed as a prop to a component that uses reference equality check on the prop to determine if it should update.
+
+## Rule details
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+<Foo bar={{ key: 'value' }} />
+```
+
+```jsx
+<Foo bar={[1, 2, 3]} />
+```
+
+```jsx
+<Foo bar={new Date()} />
+```
+
+```jsx
+<Foo bar={() => console.log('Hello!'))} />
+```
+
+```jsx
+<Foo bar={function() { alert("1337") }} />
+```
+
+```jsx
+<Foo bar={Symbol('Hi')} />
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+var bar = { key: 'value' };
+<Foo bar={bar} />
+```
+
+```jsx
+var bar = [1, 2, 3];
+<Foo bar={bar} />
+```
+
+etc., etc.
+
+
+## Rule Options
+
+```js
+...
+"react/jsx-no-update-forcing-props": [<enabled>, { "functions": <boolean> }]
+...
+```
+
+### `objectExpressions`
+
+When `false` the rule will not allow objects as prop values.
+
+Defaults to `false`.
+
+### `arrayExpressions`
+
+When `false` the rule will not allow arrays as prop values.
+
+Defaults to `false`.
+
+### `functionExpressions`
+
+When `false` the rule will not allow functions as prop values.
+
+Defaults to `false`.
+
+### `arrowFunctionExpressions`
+
+When `false` the rule will not allow arrow functions as prop values.
+
+Defaults to `false`.
+
+### `newExpressions`
+
+When `false` the rule will not allow constructor expressions as prop values.
+
+Defaults to `false`.
+
+### `callExpressions`
+
+When `false` the rule will not allow function calls as prop values.
+
+Defaults to `false`.
+
+### `ignoreRefs`
+
+When `false` the rule will not allow any of the above in `ref` props as well.
+
+Defaults to `true`.

--- a/index.js
+++ b/index.js
@@ -42,6 +42,7 @@ const allRules = {
   'jsx-no-useless-fragment': require('./lib/rules/jsx-no-useless-fragment'),
   'jsx-one-expression-per-line': require('./lib/rules/jsx-one-expression-per-line'),
   'jsx-no-undef': require('./lib/rules/jsx-no-undef'),
+  'jsx-no-update-forcing-props': require('./lib/rules/jsx-no-update-forcing-props'),
   'jsx-curly-brace-presence': require('./lib/rules/jsx-curly-brace-presence'),
   'jsx-pascal-case': require('./lib/rules/jsx-pascal-case'),
   'jsx-fragments': require('./lib/rules/jsx-fragments'),

--- a/lib/rules/jsx-no-update-forcing-props.js
+++ b/lib/rules/jsx-no-update-forcing-props.js
@@ -1,0 +1,117 @@
+/**
+ * @fileoverview Prevent usage of props that would cause the component to render every time its parent renders
+ * @author Wojciech Maj
+ */
+
+'use strict';
+
+const propName = require('jsx-ast-utils/propName');
+const docsUrl = require('../util/docsUrl');
+const jsxUtil = require('../util/jsx');
+
+const typeToName = {
+  object: 'Objects',
+  array: 'Arrays',
+  func: 'Functions',
+  arrowFunc: 'Functions',
+  new: 'Constructor expressions',
+  call: 'Function calls'
+};
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Prevent usage of props that would cause the component to render every time its parent renders',
+      category: 'Best Practices',
+      recommended: false,
+      url: docsUrl('jsx-no-update-forcing-props')
+    },
+    schema: [{
+      type: 'object',
+      properties: {
+        objectExpressions: {
+          default: false,
+          type: 'boolean'
+        },
+        arrayExpressions: {
+          default: false,
+          type: 'boolean'
+        },
+        functionExpressions: {
+          default: false,
+          type: 'boolean'
+        },
+        arrowFunctionExpressions: {
+          default: false,
+          type: 'boolean'
+        },
+        newExpressions: {
+          default: false,
+          type: 'boolean'
+        },
+        callExpressions: {
+          default: false,
+          type: 'boolean'
+        },
+        ignoreRefs: {
+          default: true,
+          type: 'boolean'
+        }
+      },
+      additionalProperties: false
+    }]
+  },
+
+  create(context) {
+    const config = context.options[0] || {};
+
+    function getNodeViolationType(node) {
+      const nodeType = node.type;
+
+      if (!config.objectExpressions && nodeType === 'ObjectExpression') {
+        return 'object';
+      }
+      if (!config.arrayExpressions && nodeType === 'ArrayExpression') {
+        return 'array';
+      }
+      if (!config.functionExpressions && nodeType === 'FunctionExpression') {
+        return 'func';
+      }
+      if (!config.arrowFunctionExpressions && nodeType === 'ArrowFunctionExpression') {
+        return 'arrowFunc';
+      }
+      if (!config.newExpressions && nodeType === 'NewExpression') {
+        return 'new';
+      }
+      if (!config.callExpressions && nodeType === 'CallExpression') {
+        return 'call';
+      }
+
+      return null;
+    }
+
+    return {
+      JSXAttribute(node) {
+        const isDOMComponent = jsxUtil.isDOMComponent(node.parent);
+        if (isDOMComponent) {
+          return;
+        }
+
+        const shouldIgnoreRefsAndIsRef = config.ignoreRefs && propName(node) === 'ref';
+        if (shouldIgnoreRefsAndIsRef || !node.value || !node.value.expression) {
+          return;
+        }
+
+        const valueNode = node.value.expression;
+        const nodeViolationType = getNodeViolationType(valueNode);
+
+        if (nodeViolationType) {
+          context.report({
+            node,
+            message: `${typeToName[nodeViolationType]} must be defined outside render function to avoid unnecessary component rerenders.`
+          });
+        }
+      }
+    };
+  }
+};

--- a/tests/lib/rules/jsx-no-update-forcing-props.js
+++ b/tests/lib/rules/jsx-no-update-forcing-props.js
@@ -1,0 +1,139 @@
+/**
+ * @fileoverview Tests for jsx-no-update-forcing-props
+ * @author Wojciech Maj
+ */
+
+'use strict';
+
+const eslint = require('eslint');
+const rule = require('../../../lib/rules/jsx-no-update-forcing-props');
+
+const RuleTester = eslint.RuleTester;
+
+const parsers = require('../../helpers/parsers');
+
+const parserOptions = {
+  ecmaVersion: 2018,
+  sourceType: 'module',
+  ecmaFeatures: {
+    jsx: true
+  }
+};
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({parserOptions});
+
+ruleTester.run('jsx-no-update-forcing-props', rule, {
+  valid: [
+    {code: '<App foo />;'},
+    {
+      code: '<App foo />;',
+      parser: parsers.BABEL_ESLINT
+    },
+    {code: '<App foo={true} />;'},
+    {code: '<App foo={1} />;'},
+    {code: '<App foo="bar" />;'},
+    {code: 'var bar = {}; <App foo={bar} />;'},
+    {code: 'var bar = []; <App foo={bar} />;'},
+    {code: 'function bar() {}; <App foo={bar} />;'},
+    {code: 'var bar = () => {}; <App foo={bar} />;'},
+    {code: 'var bar = new Date(); <App foo={bar} />;'},
+    {code: 'var bar = Symbol(\'\'); <App foo={bar} />;'},
+
+    // object expressions explicitly allowed
+    {
+      code: '<App ref={{}} />',
+      options: [{objectExpressions: true}]
+    },
+
+    // array expressions explicitly allowed
+    {
+      code: '<App ref={[]} />',
+      options: [{arrayExpressions: true}]
+    },
+
+    // function expressions explicitly allowed
+    {
+      code: '<App ref={function() {}} />',
+      options: [{functionExpressions: true}]
+    },
+
+    // arrow function expressions explicitly allowed
+    {
+      code: '<App ref={() => {}} />',
+      options: [{arrowFunctionExpressions: true}]
+    },
+
+    // new expressions explicitly allowed
+    {
+      code: '<App ref={new Date()} />',
+      options: [{newExpressions: true}]
+    },
+
+    // call expressions explicitly allowed
+    {
+      code: '<App ref={Symbol(\'\')} />',
+      options: [{callExpressions: true}]
+    },
+
+    // ref explicitly ignored
+    {
+      code: '<App ref={c => this._input = c} />',
+      options: [{ignoreRefs: true}]
+    },
+
+    // ignore DOM components
+    {
+      code: '<div foo={{}} />'
+    },
+    {
+      code: '<div foo={[]} />'
+    },
+    {
+      code: '<div foo={function() {}} />'
+    },
+    {
+      code: '<div foo={() => {}} />'
+    },
+    {
+      code: '<div foo={new Date()} />'
+    },
+    {
+      code: '<div foo={Symbol(\'\')} />'
+    }
+  ],
+  invalid: [
+    {
+      code: '<App foo={{}} />',
+      errors: [{message: 'Objects must be defined outside render function to avoid unnecessary component rerenders.'}]
+    },
+    {
+      code: '<App foo={{}} />',
+      parser: parsers.BABEL_ESLINT,
+      errors: [{message: 'Objects must be defined outside render function to avoid unnecessary component rerenders.'}]
+    },
+    {
+      code: '<App foo={[]} />',
+      errors: [{message: 'Arrays must be defined outside render function to avoid unnecessary component rerenders.'}]
+    },
+    {
+      code: '<App foo={function() {}} />',
+      errors: [{message: 'Functions must be defined outside render function to avoid unnecessary component rerenders.'}]
+    },
+    {
+      code: '<App foo={() => {}} />',
+      errors: [{message: 'Functions must be defined outside render function to avoid unnecessary component rerenders.'}]
+    },
+    {
+      code: '<App foo={new Date()} />',
+      errors: [{message: 'Constructor expressions must be defined outside render function to avoid unnecessary component rerenders.'}]
+    },
+    {
+      code: '<App foo={Symbol(\'\')} />',
+      errors: [{message: 'Function calls must be defined outside render function to avoid unnecessary component rerenders.'}]
+    }
+  ]
+});


### PR DESCRIPTION
Replaces #2024

Warns you if you have passed a prop with a value that will be [referentially unequal](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Comparison_Operators#Identity_strict_equality_()) on each render. This is bad for performance, as it will result in the garbage collector being invoked way more than is necessary. It may also cause unnecessary re-renders if a brand new object or function is passed as a prop to a component that uses reference equality check on the prop to determine if it should update.

Fixes #1633. Closes #1888.