### PR TITLE
[Fix] `jsx-no-literals`: properly handle HTML entities when allowed

### DIFF
--- a/lib/rules/jsx-no-literals.js
+++ b/lib/rules/jsx-no-literals.js
@@ -89,9 +89,11 @@ module.exports = {
     }
 
     function getValidation(node) {
-      if (config.allowedStrings.has(trimIfString(node.value))) {
+      const values = [trimIfString(node.raw), trimIfString(node.value)];
+      if (values.some((value) => config.allowedStrings.has(value))) {
         return false;
       }
+
       const parent = getParentIgnoringBinaryExpressions(node);
 
       function isParentNodeStandard() {

--- a/tests/lib/rules/jsx-no-literals.js
+++ b/tests/lib/rules/jsx-no-literals.js
@@ -284,6 +284,18 @@ ruleTester.run('jsx-no-literals', rule, {
         <img alt='blank image'></img>
       `,
     },
+    {
+      code: `
+        <div>&mdash;</div>
+      `,
+      options: [{ noStrings: true, allowedStrings: ['&mdash;', '—'] }],
+    },
+    {
+      code: `
+        <div>—</div>
+      `,
+      options: [{ noStrings: true, allowedStrings: ['&mdash;', '—'] }],
+    },
   ]),
 
   invalid: parsers.all([


### PR DESCRIPTION
When an HTML entity such as &mdash; is checked with ESLint, the `value`
property becomes the actual unicode character instead of the raw
literal.

This means if `&mdash;` is in the allowed strings array, and `&mdash;`
is in the code being checked, the actual value used in the JSXText check
will be `—`, which will not match against `&mdash;`, so it causes a
false positive error.

When checking against the set of allowed strings, this will now check
both the `value` and the `raw` properties of the node. For `&mdash;`, the
`raw` property will still be `&mdash;`.

If _either_ of these match the list of allowed values, then no error
will be returned.

I am very new to the project so if this is not the right fix, I will not be offended if you close the PR. 😆 

Fixes #3130