### PR TITLE
Remove `david-dm` badge from `README`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 * [Docs] [`jsx-no-useless-fragment`]: add more examples of correct code ([#3349][] @karlhorky)
 * [Docs] [`jsx-boolean-value`]: add jsdoc types for helper functions ([#3344][] @caroline223)
 * [readme] remove dead codeclimate badge, add actions badge (@ljharb)
+* [readme] Remove dead david-dm badge ([#3262][] @ddzz)
 
 [#3350]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3350
 [#3349]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3349
@@ -46,6 +47,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 [#3315]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3315
 [#3314]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3314
 [#3311]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3311
+[#3262]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3262
 
 ## [7.30.1] - 2022.06.23
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![github actions][actions-image]][actions-url]
 [![Maintenance Status][status-image]][status-url]
 [![NPM version][npm-image]][npm-url]
-[![Dependency Status][deps-image]][deps-url]
 [![Tidelift][tidelift-image]][tidelift-url]
 
 React specific linting rules for `eslint`
@@ -270,9 +269,6 @@ This pairs well with the `eslint:all` rule.
 
 [npm-url]: https://npmjs.org/package/eslint-plugin-react
 [npm-image]: https://img.shields.io/npm/v/eslint-plugin-react.svg
-
-[deps-url]: https://david-dm.org/jsx-eslint/eslint-plugin-react
-[deps-image]: https://img.shields.io/david/dev/jsx-eslint/eslint-plugin-react.svg
 
 [status-url]: https://github.com/jsx-eslint/eslint-plugin-react/pulse
 [status-image]: https://img.shields.io/github/last-commit/jsx-eslint/eslint-plugin-react.svg


### PR DESCRIPTION
The `david-dm` service is no longer available, so this badge can be removed from the `README`.