### PR TITLE
[Refactor] `no-deprecated`: improve performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,9 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 * [Docs] [`no-unused-prop-types`]: fix syntax errors ([#3259][] @mrdulin)
 * [Refactor] improve performance for detecting function components ([#3265][] @golopot)
 * [Refactor] improve performance for detecting class components ([#3267][] @golopot)
+* [Refactor] [`no-deprecated`]: improve performance ([#3271][] @golopot)
 
+[#3271]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3271
 [#3267]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3267
 [#3266]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3266
 [#3265]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3265

--- a/lib/rules/no-deprecated.js
+++ b/lib/rules/no-deprecated.js
@@ -29,6 +29,63 @@ const MODULES = {
 // Rule Definition
 // ------------------------------------------------------------------------------
 
+function getDeprecated(pragma) {
+  const deprecated = {};
+  // 0.12.0
+  deprecated[`${pragma}.renderComponent`] = ['0.12.0', `${pragma}.render`];
+  deprecated[`${pragma}.renderComponentToString`] = ['0.12.0', `${pragma}.renderToString`];
+  deprecated[`${pragma}.renderComponentToStaticMarkup`] = ['0.12.0', `${pragma}.renderToStaticMarkup`];
+  deprecated[`${pragma}.isValidComponent`] = ['0.12.0', `${pragma}.isValidElement`];
+  deprecated[`${pragma}.PropTypes.component`] = ['0.12.0', `${pragma}.PropTypes.element`];
+  deprecated[`${pragma}.PropTypes.renderable`] = ['0.12.0', `${pragma}.PropTypes.node`];
+  deprecated[`${pragma}.isValidClass`] = ['0.12.0'];
+  deprecated['this.transferPropsTo'] = ['0.12.0', 'spread operator ({...})'];
+  // 0.13.0
+  deprecated[`${pragma}.addons.classSet`] = ['0.13.0', 'the npm module classnames'];
+  deprecated[`${pragma}.addons.cloneWithProps`] = ['0.13.0', `${pragma}.cloneElement`];
+  // 0.14.0
+  deprecated[`${pragma}.render`] = ['0.14.0', 'ReactDOM.render'];
+  deprecated[`${pragma}.unmountComponentAtNode`] = ['0.14.0', 'ReactDOM.unmountComponentAtNode'];
+  deprecated[`${pragma}.findDOMNode`] = ['0.14.0', 'ReactDOM.findDOMNode'];
+  deprecated[`${pragma}.renderToString`] = ['0.14.0', 'ReactDOMServer.renderToString'];
+  deprecated[`${pragma}.renderToStaticMarkup`] = ['0.14.0', 'ReactDOMServer.renderToStaticMarkup'];
+  // 15.0.0
+  deprecated[`${pragma}.addons.LinkedStateMixin`] = ['15.0.0'];
+  deprecated['ReactPerf.printDOM'] = ['15.0.0', 'ReactPerf.printOperations'];
+  deprecated['Perf.printDOM'] = ['15.0.0', 'Perf.printOperations'];
+  deprecated['ReactPerf.getMeasurementsSummaryMap'] = ['15.0.0', 'ReactPerf.getWasted'];
+  deprecated['Perf.getMeasurementsSummaryMap'] = ['15.0.0', 'Perf.getWasted'];
+  // 15.5.0
+  deprecated[`${pragma}.createClass`] = ['15.5.0', 'the npm module create-react-class'];
+  deprecated[`${pragma}.addons.TestUtils`] = ['15.5.0', 'ReactDOM.TestUtils'];
+  deprecated[`${pragma}.PropTypes`] = ['15.5.0', 'the npm module prop-types'];
+  // 15.6.0
+  deprecated[`${pragma}.DOM`] = ['15.6.0', 'the npm module react-dom-factories'];
+  // 16.9.0
+  // For now the following life-cycle methods are just legacy, not deprecated:
+  // `componentWillMount`, `componentWillReceiveProps`, `componentWillUpdate`
+  // https://github.com/yannickcr/eslint-plugin-react/pull/1750#issuecomment-425975934
+  deprecated.componentWillMount = [
+    '16.9.0',
+    'UNSAFE_componentWillMount',
+    'https://reactjs.org/docs/react-component.html#unsafe_componentwillmount. '
+    + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.',
+  ];
+  deprecated.componentWillReceiveProps = [
+    '16.9.0',
+    'UNSAFE_componentWillReceiveProps',
+    'https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. '
+    + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.',
+  ];
+  deprecated.componentWillUpdate = [
+    '16.9.0',
+    'UNSAFE_componentWillUpdate',
+    'https://reactjs.org/docs/react-component.html#unsafe_componentwillupdate. '
+    + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.',
+  ];
+  return deprecated;
+}
+
 const messages = {
   deprecated: '{{oldMethod}} is deprecated since React {{version}}{{newMethod}}{{refs}}',
 };
@@ -49,67 +106,9 @@ module.exports = {
 
   create: Components.detect((context, components, utils) => {
     const pragma = pragmaUtil.getFromContext(context);
-
-    function getDeprecated() {
-      const deprecated = {};
-      // 0.12.0
-      deprecated[`${pragma}.renderComponent`] = ['0.12.0', `${pragma}.render`];
-      deprecated[`${pragma}.renderComponentToString`] = ['0.12.0', `${pragma}.renderToString`];
-      deprecated[`${pragma}.renderComponentToStaticMarkup`] = ['0.12.0', `${pragma}.renderToStaticMarkup`];
-      deprecated[`${pragma}.isValidComponent`] = ['0.12.0', `${pragma}.isValidElement`];
-      deprecated[`${pragma}.PropTypes.component`] = ['0.12.0', `${pragma}.PropTypes.element`];
-      deprecated[`${pragma}.PropTypes.renderable`] = ['0.12.0', `${pragma}.PropTypes.node`];
-      deprecated[`${pragma}.isValidClass`] = ['0.12.0'];
-      deprecated['this.transferPropsTo'] = ['0.12.0', 'spread operator ({...})'];
-      // 0.13.0
-      deprecated[`${pragma}.addons.classSet`] = ['0.13.0', 'the npm module classnames'];
-      deprecated[`${pragma}.addons.cloneWithProps`] = ['0.13.0', `${pragma}.cloneElement`];
-      // 0.14.0
-      deprecated[`${pragma}.render`] = ['0.14.0', 'ReactDOM.render'];
-      deprecated[`${pragma}.unmountComponentAtNode`] = ['0.14.0', 'ReactDOM.unmountComponentAtNode'];
-      deprecated[`${pragma}.findDOMNode`] = ['0.14.0', 'ReactDOM.findDOMNode'];
-      deprecated[`${pragma}.renderToString`] = ['0.14.0', 'ReactDOMServer.renderToString'];
-      deprecated[`${pragma}.renderToStaticMarkup`] = ['0.14.0', 'ReactDOMServer.renderToStaticMarkup'];
-      // 15.0.0
-      deprecated[`${pragma}.addons.LinkedStateMixin`] = ['15.0.0'];
-      deprecated['ReactPerf.printDOM'] = ['15.0.0', 'ReactPerf.printOperations'];
-      deprecated['Perf.printDOM'] = ['15.0.0', 'Perf.printOperations'];
-      deprecated['ReactPerf.getMeasurementsSummaryMap'] = ['15.0.0', 'ReactPerf.getWasted'];
-      deprecated['Perf.getMeasurementsSummaryMap'] = ['15.0.0', 'Perf.getWasted'];
-      // 15.5.0
-      deprecated[`${pragma}.createClass`] = ['15.5.0', 'the npm module create-react-class'];
-      deprecated[`${pragma}.addons.TestUtils`] = ['15.5.0', 'ReactDOM.TestUtils'];
-      deprecated[`${pragma}.PropTypes`] = ['15.5.0', 'the npm module prop-types'];
-      // 15.6.0
-      deprecated[`${pragma}.DOM`] = ['15.6.0', 'the npm module react-dom-factories'];
-      // 16.9.0
-      // For now the following life-cycle methods are just legacy, not deprecated:
-      // `componentWillMount`, `componentWillReceiveProps`, `componentWillUpdate`
-      // https://github.com/jsx-eslint/eslint-plugin-react/pull/1750#issuecomment-425975934
-      deprecated.componentWillMount = [
-        '16.9.0',
-        'UNSAFE_componentWillMount',
-        'https://reactjs.org/docs/react-component.html#unsafe_componentwillmount. '
-        + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.',
-      ];
-      deprecated.componentWillReceiveProps = [
-        '16.9.0',
-        'UNSAFE_componentWillReceiveProps',
-        'https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. '
-        + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.',
-      ];
-      deprecated.componentWillUpdate = [
-        '16.9.0',
-        'UNSAFE_componentWillUpdate',
-        'https://reactjs.org/docs/react-component.html#unsafe_componentwillupdate. '
-        + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.',
-      ];
-      return deprecated;
-    }
+    const deprecated = getDeprecated(pragma);
 
     function isDeprecated(method) {
-      const deprecated = getDeprecated();
-
       return (
         deprecated
         && deprecated[method]
@@ -122,7 +121,6 @@ module.exports = {
       if (!isDeprecated(methodName)) {
         return;
       }
-      const deprecated = getDeprecated();
       const version = deprecated[methodName][0];
       const newMethod = deprecated[methodName][1];
       const refs = deprecated[methodName][2];


### PR DESCRIPTION
🤔 Call `getDeprecated` for every MemberExpression.
🙂 Call `getDeprecated` for every file linted.

Benchmark with `TIMING=10 npx eslint .`:
```diff
- react/no-deprecated                  |   658.734 |     4.8%
+ react/no-deprecated                  |   324.518 |     2.4%

```