### PR TITLE
[Refactor] `no-*-set-state`: improve performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,9 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 * [Refactor] improve performance for detecting function components ([#3265][] @golopot)
 * [Refactor] improve performance for detecting class components ([#3267][] @golopot)
 * [Refactor] [`no-deprecated`]: improve performance ([#3271][] @golopot)
+* [Refactor] [`no-did-mount-set-state`], [`no-did-update-set-state`], [`no-will-update-set-state`]: improve performance ([#3272][] @golopot)
 
+[#3272]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3272
 [#3271]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3271
 [#3267]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3267
 [#3266]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3266

--- a/lib/util/makeNoMethodSetStateRule.js
+++ b/lib/util/makeNoMethodSetStateRule.js
@@ -73,16 +73,16 @@ module.exports = function makeNoMethodSetStateRule(methodName, shouldCheckUnsafe
         return false;
       }
 
+      if (shouldBeNoop(context, methodName)) {
+        return {};
+      }
+
       // --------------------------------------------------------------------------
       // Public
       // --------------------------------------------------------------------------
 
       return {
         CallExpression(node) {
-          if (shouldBeNoop(context, methodName)) {
-            return;
-          }
-
           const callee = node.callee;
           if (
             callee.type !== 'MemberExpression'


### PR DESCRIPTION
❌ Early return on CallExpression
✔️ Early return on rule creation

Benchmark:
```diff

- react/no-did-mount-set-state               |   602.202 |     4.5%
- react/no-did-update-set-state              |   302.628 |     2.3%
- react/no-will-update-set-state             |    10.411 |     0.1%
+ react/no-did-mount-set-state               |     7.566 |     0.1%
+ react/no-will-update-set-state             |     4.627 |     0.0%
+ react/no-did-update-set-state              |     3.381 |     0.0%
```