### PR TITLE
[Refactor] improve performance of component detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,10 +32,12 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 * [Refactor] add `isParenthesized` AST util ([#3203][] @Belco90)
 * [Docs] `default-props-match-prop-types`, `require-default-props`, `sort-prop-types`: fix typos ([#3279][] @nix6839)
 * [Refactor] improve performance of rule merging ([#3281][] @golopot)
+* [Refactor] improve performance of component detection ([#3276][] @golopot)
 
 [#3281]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3281
 [#3280]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3280
 [#3279]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3279
+[#3276]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3276
 [#3273]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3273
 [#3272]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3272
 [#3271]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3271

--- a/lib/util/Components.js
+++ b/lib/util/Components.js
@@ -782,14 +782,6 @@ function componentRule(rule, context) {
       components.add(node, 2);
     },
 
-    'ClassProperty, PropertyDefinition'(node) {
-      node = utils.getParentComponent();
-      if (!node) {
-        return;
-      }
-      components.add(node, 2);
-    },
-
     ObjectExpression(node) {
       if (!componentUtil.isES5Component(node, context)) {
         return;
@@ -812,7 +804,7 @@ function componentRule(rule, context) {
         components.add(node, 0);
         return;
       }
-      components.add(component, 1);
+      components.add(component, 2);
     },
 
     FunctionDeclaration(node) {
@@ -825,7 +817,7 @@ function componentRule(rule, context) {
       if (!node) {
         return;
       }
-      components.add(node, 1);
+      components.add(node, 2);
     },
 
     ArrowFunctionExpression(node) {
@@ -843,33 +835,16 @@ function componentRule(rule, context) {
         components.add(node, 0);
         return;
       }
-      if (component.expression && utils.isReturningJSX(component)) {
-        components.add(component, 2);
-      } else {
-        components.add(component, 1);
-      }
+      components.add(component, 2);
     },
 
     ThisExpression(node) {
-      const component = utils.getParentComponent();
+      const component = utils.getParentStatelessComponent();
       if (!component || !/Function/.test(component.type) || !node.parent.property) {
         return;
       }
       // Ban functions accessing a property on a ThisExpression
       components.add(node, 0);
-    },
-
-    ReturnStatement(node) {
-      if (!utils.isReturningJSX(node)) {
-        return;
-      }
-      node = utils.getParentComponent();
-      if (!node) {
-        const scope = context.getScope();
-        components.add(scope.block, 1);
-        return;
-      }
-      components.add(node, 2);
     },
   };
 


### PR DESCRIPTION
Some node visitors for components detection are redundant.

Benchmark with `time npx eslint .` (mean of 5 runs):

```diff
- 5.06 s
+ 5.01 s
```