### PR TITLE
[Fix] `display-name`: fix false positive for HOF returning only nulls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 
 ## Unreleased
 
+### Fixed
+* [`display-name`]: fix false positive for HOF returning only nulls ([#3291][] @golopot)
+
+[#3291]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3291
+
 ## [7.30.0] - 2022.05.18
 
 ### Added

--- a/lib/util/Components.js
+++ b/lib/util/Components.js
@@ -498,8 +498,13 @@ function componentRule(rule, context) {
           return undefined;
         }
 
-        // case: function any() { return (props) { return not-jsx-and-not-null } }
-        if (node.parent.type === 'ReturnStatement' && !utils.isReturningJSX(node) && !utils.isReturningOnlyNull(node)) {
+        // case: const any = () => { return (props) => null }
+        // case: const any = () => (props) => null
+        if (
+          (node.parent.type === 'ReturnStatement' || (node.parent.type === 'ArrowFunctionExpression' && node.parent.expression))
+          && !utils.isReturningJSX(node)
+          && !utils.isReturningOnlyNull(node)
+        ) {
           return undefined;
         }
 

--- a/tests/lib/rules/display-name.js
+++ b/tests/lib/rules/display-name.js
@@ -579,6 +579,15 @@ ruleTester.run('display-name', rule, {
         }
       `,
     },
+    {
+      // issue #3289
+      code: `
+        export const demo = (a) => (b) => {
+          if (a == null) return null;
+          return b;
+        }
+      `,
+    },
   ]),
 
   invalid: parsers.all([


### PR DESCRIPTION
Fixes #3289.

Stop considering `const any = () => (props) => null` as a component.
