### PR TITLE
[Fix] `display-name`: fix false positive when using memo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,13 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 ### Fixed
 * [`display-name`]: fix false positive for HOF returning only nulls ([#3291][] @golopot)
 * [`jsx-no-leaked-render`]: avoid unnecessary negation operators and ternary branches deletion ([#3299][] @Belco90)
+* [`display-name`]: fix false positive when using memo ([#3304][] @golopot)
 
 ### Changed
 * [Docs] [`jsx-tag-spacing`]: rename option from [#3264][] ([#3294[] @ljharb)
 * [Docs] [`jsx-key`]: split the examples ([#3293][] @ioggstream)
 
+[#3304]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3304
 [#3299]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3299
 [#3294]: https://github.com/jsx-eslint/eslint-plugin-react/issues/3294
 [#3293]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3293

--- a/lib/util/Components.js
+++ b/lib/util/Components.js
@@ -515,7 +515,7 @@ function componentRule(rule, context) {
 
         // Case like `React.memo(() => <></>)` or `React.forwardRef(...)`
         const pragmaComponentWrapper = utils.getPragmaComponentWrapper(node);
-        if (pragmaComponentWrapper) {
+        if (pragmaComponentWrapper && utils.isReturningJSXOrNull(node)) {
           return pragmaComponentWrapper;
         }
 

--- a/tests/lib/rules/display-name.js
+++ b/tests/lib/rules/display-name.js
@@ -588,6 +588,19 @@ ruleTester.run('display-name', rule, {
         }
       `,
     },
+    {
+      // issue #3303
+      code: `
+        function MyComponent(props) {
+          return <b>{props.name}</b>;
+        }
+            
+        const MemoizedMyComponent = React.memo(
+          MyComponent,
+          (prevProps, nextProps) => prevProps.name === nextProps.name
+        )
+      `,
+    },
   ]),
 
   invalid: parsers.all([


### PR DESCRIPTION
Fix #3303.

PR #3276 caused the following to be considered a component, while in v7.29.0 it is not considered a component:

```js
const MemoizedMyComponent = React.memo(
  MyComponent,
  () => 1
)
```

This PR adds a check that the function being wrapped must return JSX to be considered a component.

The bug is so subtle and I am not sure this is the right way to fix it.
