### PR TITLE
[Fix] `display-name`: fix false positive for HOF returning only nulls and literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 * [`require-default-props`]: avoid a crash when function has no props param ([#3350][] @noahnu)
 * [`display-name`], component detection: fix HOF returning null as Components ([#3347][] @jxm-math)
 * [`forbid-prop-types`]: Ignore objects that are not of type React.PropTypes ([#3326][] @TildaDares)
+* [`display-name`], component detection: fix false positive for HOF returning only nulls and literals ([#3305][] @golopot)
 
 ### Changed
 * [Refactor] [`jsx-indent-props`]: improved readability of the checkNodesIndent function ([#3315][] @caroline223)
@@ -49,6 +50,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 [#3315]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3315
 [#3314]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3314
 [#3311]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3311
+[#3305]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3305
 [#3262]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3262
 
 ## [7.30.1] - 2022.06.23

--- a/lib/util/Components.js
+++ b/lib/util/Components.js
@@ -503,7 +503,6 @@ function componentRule(rule, context) {
         if (
           (node.parent.type === 'ReturnStatement' || (node.parent.type === 'ArrowFunctionExpression' && node.parent.expression))
           && !utils.isReturningJSX(node)
-          && !utils.isReturningOnlyNull(node)
         ) {
           return undefined;
         }

--- a/tests/lib/rules/display-name.js
+++ b/tests/lib/rules/display-name.js
@@ -557,6 +557,17 @@ ruleTester.run('display-name', rule, {
       `,
     },
     {
+      // issue #3300
+      code: `
+        const f = (a) => () => {
+          if (a) {
+            return null;
+          }
+          return 1;
+        };
+      `,
+    },
+    {
       code: `
         class Test {
           render() {
@@ -1168,34 +1179,6 @@ ruleTester.run('display-name', rule, {
           line: 9,
         },
       ],
-    },
-    {
-      code: `
-        Demo = () => () => null;
-      `,
-      errors: [{ messageId: 'noDisplayName' }],
-    },
-    {
-      code: `
-        demo = {
-          Property: () => () => null
-        }
-      `,
-      errors: [{ messageId: 'noDisplayName' }],
-    },
-    {
-      code: `
-        Demo = function() {return function() {return null;};};
-      `,
-      errors: [{ messageId: 'noDisplayName' }],
-    },
-    {
-      code: `
-        demo = {
-          Property: function() {return function() {return null;};}
-        }
-      `,
-      errors: [{ messageId: 'noDisplayName' }],
     },
   ]),
 });

--- a/tests/lib/rules/no-this-in-sfc.js
+++ b/tests/lib/rules/no-this-in-sfc.js
@@ -275,58 +275,5 @@ ruleTester.run('no-this-in-sfc', rule, {
         { messageId: 'noThisInSFC' },
       ],
     },
-    {
-      code: `
-        class Foo {
-          bar() {
-            return () => {
-              this.something();
-              return null;
-            }
-          }
-        }
-      `,
-      errors: [{ messageId: 'noThisInSFC' }],
-    },
-    {
-      code: `
-        class Foo {
-          bar = () => () => {
-            this.something();
-            return null;
-          };
-        }
-      `,
-      features: ['class fields', 'no-ts-old'], // TODO: FIXME: remove `no-ts-old` and fix
-      errors: [{ messageId: 'noThisInSFC' }],
-    },
-    {
-      code: `
-        class Foo {
-          bar() {
-            function Bar(){
-              return () => {
-                this.something();
-                return null;
-              }
-            }
-          }
-        }
-      `,
-      errors: [{ messageId: 'noThisInSFC' }],
-    },
-    {
-      code: `
-        class Foo {
-          bar() {
-            () => () => {
-              this.something();
-              return null;
-            };
-          }
-        }
-      `,
-      errors: [{ messageId: 'noThisInSFC' }],
-    },
   ]),
 });


### PR DESCRIPTION
Fixes #3300.

This bug is caused by #3276.

Stop considering the following a component:
```js
const f = (a) => () => {
  if (a) {
    return null;
  }
  return 1;
};
```

The bug is triggered when a literal like `1` or `"a"` is returned somewhere.