### PR TITLE
[Docs] `jsx-no-target-blank`: Fix link to link-type-noreferrer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 * [readme] Remove dead david-dm badge ([#3262][] @ddzz)
 * [Refactor] [`jsx-closing-bracket-location`], [`jsx-no-bind`]: fix eslint issues ([#3351][] @caroline223)
 * [Tests] [`function-component-definition`]: add passing test cases ([#3355][] @TildaDares)
+* [Docs] [`jsx-no-target-blank`]: Fix link to link-type-noreferrer ([#3319][] @Luccasoli)
 
 [#3355]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3355
 [#3353]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3353
@@ -53,6 +54,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 [#3326]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3326
 [#3321]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3321
 [#3320]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3320
+[#3319]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3319
 [#3317]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3317
 [#3316]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3316
 [#3315]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3315

--- a/docs/rules/jsx-no-target-blank.md
+++ b/docs/rules/jsx-no-target-blank.md
@@ -1,6 +1,6 @@
 # Prevent usage of unsafe `target='_blank'` (react/jsx-no-target-blank)
 
-When creating a JSX element that has an `a` tag, it is often desired to have the link open in a new tab using the `target='_blank'` attribute. Using this attribute unaccompanied by `rel='noreferrer'`, however, is a severe security vulnerability ([see here for more details](https://html.spec.whatwg.org/multipage/links.html#link-type-noopener))
+When creating a JSX element that has an `a` tag, it is often desired to have the link open in a new tab using the `target='_blank'` attribute. Using this attribute unaccompanied by `rel='noreferrer'`, however, is a severe security vulnerability (see [noreferrer docs](https://html.spec.whatwg.org/multipage/links.html#link-type-noreferrer) and [noopener docs](https://html.spec.whatwg.org/multipage/links.html#link-type-noopener) for more details)
 This rules requires that you accompany `target='_blank'` attributes with `rel='noreferrer'`.
 
 ## Rule Details


### PR DESCRIPTION
I updated the link to the "noreferrer" explanation instead of a link to the "noopener" explanation, since the paragraph where this link is located only talks about the "noreferrer".