### PR TITLE
[Fix] `display-name`: fix false positive for assignment of function returning null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,14 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 * [`display-name`]: Accept forwardRef and Memo nesting in newer React versions ([#3321][] @TildaDares)
 * [`jsx-key`]: avoid a crash from optional chaining from [#3320][] ([#3327][] @ljharb)
 * [`jsx-key`]: avoid a crash on a non-array node.body from [#3320][] ([#3328][] @ljharb)
+* [`display-name`]: fix false positive for assignment of function returning null ([#3331][] @apbarrero)
 
 ### Changed
 * [Refactor] [`jsx-indent-props`]: improved readability of the checkNodesIndent function ([#3315][] @caroline223)
 * [Tests] [`jsx-indent`], [`jsx-one-expression-per-line`]: add passing test cases ([#3314][] @ROSSROSALES)
 * [Refactor] `boolean-prop-naming`, `jsx-indent`: avoid assigning to arguments ([#3316][] @caroline223)
 
+[#3331]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3331
 [#3328]: https://github.com/jsx-eslint/eslint-plugin-react/issues/3328
 [#3327]: https://github.com/jsx-eslint/eslint-plugin-react/issues/3327
 [#3321]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3321

--- a/lib/util/Components.js
+++ b/lib/util/Components.js
@@ -508,6 +508,15 @@ function componentRule(rule, context) {
           return undefined;
         }
 
+        // case: any = () => { return => null }
+        // case: any = () => null
+        if (node.parent.type === 'AssignmentExpression' && !isPropertyAssignment && utils.isReturningJSXOrNull(node)) {
+          if (isFirstLetterCapitalized(node.parent.left.name)) {
+            return node;
+          }
+          return undefined;
+        }
+
         // for case abc = { [someobject.somekey]: props => { ... return not-jsx } }
         if (node.parent && node.parent.key && node.parent.key.type === 'MemberExpression' && !utils.isReturningJSX(node) && !utils.isReturningOnlyNull(node)) {
           return undefined;

--- a/tests/lib/rules/display-name.js
+++ b/tests/lib/rules/display-name.js
@@ -589,6 +589,15 @@ ruleTester.run('display-name', rule, {
       `,
     },
     {
+      // issue #3329
+      code: `
+        let demo = null;
+        demo = (a) => {
+          if (a == null) return null;
+          return f(a);
+        };`,
+    },
+    {
       // issue #3303
       code: `
         function MyComponent(props) {


### PR DESCRIPTION
Fixes https://github.com/jsx-eslint/eslint-plugin-react/issues/3329

Stop considering `let any; any = () => null` as a component.