### PR TITLE
Consistent rule descriptions and doc sections

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -50,6 +50,7 @@
         }],
 
         "eslint-plugin/consistent-output": 0,
+        "eslint-plugin/require-meta-docs-description": [2, { "pattern": "^(Enforce|Require|Disallow)" }],
         "eslint-plugin/require-meta-schema": 0,
         "eslint-plugin/require-meta-type": 0
     },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,9 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 * [Tests] [`function-component-definition`]: add passing test cases ([#3355][] @TildaDares)
 * [Docs] [`jsx-no-target-blank`]: Fix link to link-type-noreferrer ([#3319][] @Luccasoli)
 * [Docs] document which rules provide suggestions ([#3359][] @bmish)
+* [Docs] Consistent rule descriptions and doc sections ([#3361][] @bmish)
 
+[#3361]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3361
 [#3359]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3359
 [#3355]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3355
 [#3353]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3353

--- a/README.md
+++ b/README.md
@@ -119,64 +119,64 @@ Enable the rules that you would like to use.
 | ✔ | 🔧 | 💡 | Rule | Description |
 | :---: | :---: | :---: | :--- | :--- |
 |  |  |  | [react/boolean-prop-naming](docs/rules/boolean-prop-naming.md) | Enforces consistent naming for boolean props |
-|  |  |  | [react/button-has-type](docs/rules/button-has-type.md) | Forbid "button" element without an explicit "type" attribute |
-|  |  |  | [react/default-props-match-prop-types](docs/rules/default-props-match-prop-types.md) | Enforce all defaultProps are defined and not "required" in propTypes. |
+|  |  |  | [react/button-has-type](docs/rules/button-has-type.md) | Disallow usage of `button` elements without an explicit `type` attribute |
+|  |  |  | [react/default-props-match-prop-types](docs/rules/default-props-match-prop-types.md) | Enforce all defaultProps have a corresponding non-required PropType |
 |  | 🔧 |  | [react/destructuring-assignment](docs/rules/destructuring-assignment.md) | Enforce consistent usage of destructuring assignment of props, state, and context |
-| ✔ |  |  | [react/display-name](docs/rules/display-name.md) | Prevent missing displayName in a React component definition |
-|  |  |  | [react/forbid-component-props](docs/rules/forbid-component-props.md) | Forbid certain props on components |
-|  |  |  | [react/forbid-dom-props](docs/rules/forbid-dom-props.md) | Forbid certain props on DOM Nodes |
-|  |  |  | [react/forbid-elements](docs/rules/forbid-elements.md) | Forbid certain elements |
-|  |  |  | [react/forbid-foreign-prop-types](docs/rules/forbid-foreign-prop-types.md) | Forbid using another component's propTypes |
-|  |  |  | [react/forbid-prop-types](docs/rules/forbid-prop-types.md) | Forbid certain propTypes |
-|  | 🔧 |  | [react/function-component-definition](docs/rules/function-component-definition.md) | Standardize the way function component get defined |
-|  |  | 💡 | [react/hook-use-state](docs/rules/hook-use-state.md) | Ensure symmetric naming of useState hook value and setter variables |
+| ✔ |  |  | [react/display-name](docs/rules/display-name.md) | Disallow missing displayName in a React component definition |
+|  |  |  | [react/forbid-component-props](docs/rules/forbid-component-props.md) | Disallow certain props on components |
+|  |  |  | [react/forbid-dom-props](docs/rules/forbid-dom-props.md) | Disallow certain props on DOM Nodes |
+|  |  |  | [react/forbid-elements](docs/rules/forbid-elements.md) | Disallow certain elements |
+|  |  |  | [react/forbid-foreign-prop-types](docs/rules/forbid-foreign-prop-types.md) | Disallow using another component's propTypes |
+|  |  |  | [react/forbid-prop-types](docs/rules/forbid-prop-types.md) | Disallow certain propTypes |
+|  | 🔧 |  | [react/function-component-definition](docs/rules/function-component-definition.md) | Enforce a specific function type for function components |
+|  |  | 💡 | [react/hook-use-state](docs/rules/hook-use-state.md) | Ensure destructuring and symmetric naming of useState hook value and setter variables |
 |  |  |  | [react/iframe-missing-sandbox](docs/rules/iframe-missing-sandbox.md) | Enforce sandbox attribute on iframe elements |
-|  |  |  | [react/no-access-state-in-setstate](docs/rules/no-access-state-in-setstate.md) | Reports when this.state is accessed within setState |
-|  |  |  | [react/no-adjacent-inline-elements](docs/rules/no-adjacent-inline-elements.md) | Prevent adjacent inline elements not separated by whitespace. |
-|  |  |  | [react/no-array-index-key](docs/rules/no-array-index-key.md) | Prevent usage of Array index in keys |
+|  |  |  | [react/no-access-state-in-setstate](docs/rules/no-access-state-in-setstate.md) | Disallow when this.state is accessed within setState |
+|  |  |  | [react/no-adjacent-inline-elements](docs/rules/no-adjacent-inline-elements.md) | Disallow adjacent inline elements not separated by whitespace. |
+|  |  |  | [react/no-array-index-key](docs/rules/no-array-index-key.md) | Disallow usage of Array index in keys |
 |  | 🔧 |  | [react/no-arrow-function-lifecycle](docs/rules/no-arrow-function-lifecycle.md) | Lifecycle methods should be methods on the prototype, not class fields |
-| ✔ |  |  | [react/no-children-prop](docs/rules/no-children-prop.md) | Prevent passing of children as props. |
-|  |  |  | [react/no-danger](docs/rules/no-danger.md) | Prevent usage of dangerous JSX props |
-| ✔ |  |  | [react/no-danger-with-children](docs/rules/no-danger-with-children.md) | Report when a DOM element is using both children and dangerouslySetInnerHTML |
-| ✔ |  |  | [react/no-deprecated](docs/rules/no-deprecated.md) | Prevent usage of deprecated methods |
-|  |  |  | [react/no-did-mount-set-state](docs/rules/no-did-mount-set-state.md) | Prevent usage of setState in componentDidMount |
-|  |  |  | [react/no-did-update-set-state](docs/rules/no-did-update-set-state.md) | Prevent usage of setState in componentDidUpdate |
-| ✔ |  |  | [react/no-direct-mutation-state](docs/rules/no-direct-mutation-state.md) | Prevent direct mutation of this.state |
-| ✔ |  |  | [react/no-find-dom-node](docs/rules/no-find-dom-node.md) | Prevent usage of findDOMNode |
-|  | 🔧 |  | [react/no-invalid-html-attribute](docs/rules/no-invalid-html-attribute.md) | Forbid attribute with an invalid values` |
-| ✔ |  |  | [react/no-is-mounted](docs/rules/no-is-mounted.md) | Prevent usage of isMounted |
-|  |  |  | [react/no-multi-comp](docs/rules/no-multi-comp.md) | Prevent multiple component definition per file |
+| ✔ |  |  | [react/no-children-prop](docs/rules/no-children-prop.md) | Disallow passing of children as props |
+|  |  |  | [react/no-danger](docs/rules/no-danger.md) | Disallow usage of dangerous JSX properties |
+| ✔ |  |  | [react/no-danger-with-children](docs/rules/no-danger-with-children.md) | Disallow when a DOM element is using both children and dangerouslySetInnerHTML |
+| ✔ |  |  | [react/no-deprecated](docs/rules/no-deprecated.md) | Disallow usage of deprecated methods |
+|  |  |  | [react/no-did-mount-set-state](docs/rules/no-did-mount-set-state.md) | Disallow usage of setState in componentDidMount |
+|  |  |  | [react/no-did-update-set-state](docs/rules/no-did-update-set-state.md) | Disallow usage of setState in componentDidUpdate |
+| ✔ |  |  | [react/no-direct-mutation-state](docs/rules/no-direct-mutation-state.md) | Disallow direct mutation of this.state |
+| ✔ |  |  | [react/no-find-dom-node](docs/rules/no-find-dom-node.md) | Disallow usage of findDOMNode |
+|  | 🔧 |  | [react/no-invalid-html-attribute](docs/rules/no-invalid-html-attribute.md) | Disallow usage of invalid attributes |
+| ✔ |  |  | [react/no-is-mounted](docs/rules/no-is-mounted.md) | Disallow usage of isMounted |
+|  |  |  | [react/no-multi-comp](docs/rules/no-multi-comp.md) | Disallow multiple component definition per file |
 |  |  |  | [react/no-namespace](docs/rules/no-namespace.md) | Enforce that namespaces are not used in React elements |
-|  |  |  | [react/no-redundant-should-component-update](docs/rules/no-redundant-should-component-update.md) | Flag shouldComponentUpdate when extending PureComponent |
-| ✔ |  |  | [react/no-render-return-value](docs/rules/no-render-return-value.md) | Prevent usage of the return value of React.render |
-|  |  |  | [react/no-set-state](docs/rules/no-set-state.md) | Prevent usage of setState |
-| ✔ |  |  | [react/no-string-refs](docs/rules/no-string-refs.md) | Prevent string definitions for references and prevent referencing this.refs |
-|  |  |  | [react/no-this-in-sfc](docs/rules/no-this-in-sfc.md) | Report "this" being used in stateless components |
-|  |  |  | [react/no-typos](docs/rules/no-typos.md) | Prevent common typos |
-| ✔ |  |  | [react/no-unescaped-entities](docs/rules/no-unescaped-entities.md) | Detect unescaped HTML entities, which might represent malformed tags |
-| ✔ | 🔧 |  | [react/no-unknown-property](docs/rules/no-unknown-property.md) | Prevent usage of unknown DOM property |
-|  |  |  | [react/no-unsafe](docs/rules/no-unsafe.md) | Prevent usage of unsafe lifecycle methods |
-|  |  |  | [react/no-unstable-nested-components](docs/rules/no-unstable-nested-components.md) | Prevent creating unstable components inside components |
-|  |  |  | [react/no-unused-class-component-methods](docs/rules/no-unused-class-component-methods.md) | Prevent declaring unused methods of component class |
-|  |  |  | [react/no-unused-prop-types](docs/rules/no-unused-prop-types.md) | Prevent definitions of unused prop types |
-|  |  |  | [react/no-unused-state](docs/rules/no-unused-state.md) | Prevent definition of unused state fields |
-|  |  |  | [react/no-will-update-set-state](docs/rules/no-will-update-set-state.md) | Prevent usage of setState in componentWillUpdate |
+|  |  |  | [react/no-redundant-should-component-update](docs/rules/no-redundant-should-component-update.md) | Disallow usage of shouldComponentUpdate when extending React.PureComponent |
+| ✔ |  |  | [react/no-render-return-value](docs/rules/no-render-return-value.md) | Disallow usage of the return value of ReactDOM.render |
+|  |  |  | [react/no-set-state](docs/rules/no-set-state.md) | Disallow usage of setState |
+| ✔ |  |  | [react/no-string-refs](docs/rules/no-string-refs.md) | Disallow using string references |
+|  |  |  | [react/no-this-in-sfc](docs/rules/no-this-in-sfc.md) | Disallow `this` from being used in stateless functional components |
+|  |  |  | [react/no-typos](docs/rules/no-typos.md) | Disallow common typos |
+| ✔ |  |  | [react/no-unescaped-entities](docs/rules/no-unescaped-entities.md) | Disallow unescaped HTML entities from appearing in markup |
+| ✔ | 🔧 |  | [react/no-unknown-property](docs/rules/no-unknown-property.md) | Disallow usage of unknown DOM property |
+|  |  |  | [react/no-unsafe](docs/rules/no-unsafe.md) | Disallow usage of unsafe lifecycle methods |
+|  |  |  | [react/no-unstable-nested-components](docs/rules/no-unstable-nested-components.md) | Disallow creating unstable components inside components |
+|  |  |  | [react/no-unused-class-component-methods](docs/rules/no-unused-class-component-methods.md) | Disallow declaring unused methods of component class |
+|  |  |  | [react/no-unused-prop-types](docs/rules/no-unused-prop-types.md) | Disallow definitions of unused propTypes |
+|  |  |  | [react/no-unused-state](docs/rules/no-unused-state.md) | Disallow definitions of unused state |
+|  |  |  | [react/no-will-update-set-state](docs/rules/no-will-update-set-state.md) | Disallow usage of setState in componentWillUpdate |
 |  |  |  | [react/prefer-es6-class](docs/rules/prefer-es6-class.md) | Enforce ES5 or ES6 class for React Components |
 |  |  |  | [react/prefer-exact-props](docs/rules/prefer-exact-props.md) | Prefer exact proptype definitions |
-|  | 🔧 |  | [react/prefer-read-only-props](docs/rules/prefer-read-only-props.md) | Require read-only props. |
+|  | 🔧 |  | [react/prefer-read-only-props](docs/rules/prefer-read-only-props.md) | Enforce that props are read-only |
 |  |  |  | [react/prefer-stateless-function](docs/rules/prefer-stateless-function.md) | Enforce stateless components to be written as a pure function |
-| ✔ |  |  | [react/prop-types](docs/rules/prop-types.md) | Prevent missing props validation in a React component definition |
-| ✔ |  |  | [react/react-in-jsx-scope](docs/rules/react-in-jsx-scope.md) | Prevent missing React when using JSX |
-|  |  |  | [react/require-default-props](docs/rules/require-default-props.md) | Enforce a defaultProps definition for every prop that is not a required prop. |
+| ✔ |  |  | [react/prop-types](docs/rules/prop-types.md) | Disallow missing props validation in a React component definition |
+| ✔ |  |  | [react/react-in-jsx-scope](docs/rules/react-in-jsx-scope.md) | Disallow missing React when using JSX |
+|  |  |  | [react/require-default-props](docs/rules/require-default-props.md) | Enforce a defaultProps definition for every prop that is not a required prop |
 |  |  |  | [react/require-optimization](docs/rules/require-optimization.md) | Enforce React components to have a shouldComponentUpdate method |
 | ✔ |  |  | [react/require-render-return](docs/rules/require-render-return.md) | Enforce ES5 or ES6 class for returning value in render function |
-|  | 🔧 |  | [react/self-closing-comp](docs/rules/self-closing-comp.md) | Prevent extra closing tags for components without children |
+|  | 🔧 |  | [react/self-closing-comp](docs/rules/self-closing-comp.md) | Disallow extra closing tags for components without children |
 |  |  |  | [react/sort-comp](docs/rules/sort-comp.md) | Enforce component methods order |
 |  |  |  | [react/sort-prop-types](docs/rules/sort-prop-types.md) | Enforce propTypes declarations alphabetical sorting |
-|  |  |  | [react/state-in-constructor](docs/rules/state-in-constructor.md) | State initialization in an ES6 class component should be in a constructor |
-|  |  |  | [react/static-property-placement](docs/rules/static-property-placement.md) | Defines where React component static properties should be positioned. |
+|  |  |  | [react/state-in-constructor](docs/rules/state-in-constructor.md) | Enforce class component state initialization style |
+|  |  |  | [react/static-property-placement](docs/rules/static-property-placement.md) | Enforces where React component static properties should be positioned. |
 |  |  |  | [react/style-prop-object](docs/rules/style-prop-object.md) | Enforce style prop value is an object |
-|  |  |  | [react/void-dom-elements-no-children](docs/rules/void-dom-elements-no-children.md) | Prevent passing of children to void DOM elements (e.g. `<br />`). |
+|  |  |  | [react/void-dom-elements-no-children](docs/rules/void-dom-elements-no-children.md) | Disallow void DOM elements (e.g. `<img />`, `<br />`) from receiving children |
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## JSX-specific rules
@@ -185,44 +185,44 @@ Enable the rules that you would like to use.
 | ✔ | 🔧 | 💡 | Rule | Description |
 | :---: | :---: | :---: | :--- | :--- |
 |  | 🔧 |  | [react/jsx-boolean-value](docs/rules/jsx-boolean-value.md) | Enforce boolean attributes notation in JSX |
-|  |  |  | [react/jsx-child-element-spacing](docs/rules/jsx-child-element-spacing.md) | Ensures inline tags are not rendered without spaces between them |
-|  | 🔧 |  | [react/jsx-closing-bracket-location](docs/rules/jsx-closing-bracket-location.md) | Validate closing bracket location in JSX |
-|  | 🔧 |  | [react/jsx-closing-tag-location](docs/rules/jsx-closing-tag-location.md) | Validate closing tag location for multiline JSX |
-|  | 🔧 |  | [react/jsx-curly-brace-presence](docs/rules/jsx-curly-brace-presence.md) | Disallow unnecessary JSX expressions when literals alone are sufficient or enfore JSX expressions on literals in JSX children or attributes |
-|  | 🔧 |  | [react/jsx-curly-newline](docs/rules/jsx-curly-newline.md) | Enforce consistent line breaks inside jsx curly |
-|  | 🔧 |  | [react/jsx-curly-spacing](docs/rules/jsx-curly-spacing.md) | Enforce or disallow spaces inside of curly braces in JSX attributes |
-|  | 🔧 |  | [react/jsx-equals-spacing](docs/rules/jsx-equals-spacing.md) | Disallow or enforce spaces around equal signs in JSX attributes |
-|  |  |  | [react/jsx-filename-extension](docs/rules/jsx-filename-extension.md) | Restrict file extensions that may contain JSX |
-|  | 🔧 |  | [react/jsx-first-prop-new-line](docs/rules/jsx-first-prop-new-line.md) | Ensure proper position of the first property in JSX |
+|  |  |  | [react/jsx-child-element-spacing](docs/rules/jsx-child-element-spacing.md) | Enforce or disallow spaces inside of curly braces in JSX attributes and expressions |
+|  | 🔧 |  | [react/jsx-closing-bracket-location](docs/rules/jsx-closing-bracket-location.md) | Enforce closing bracket location in JSX |
+|  | 🔧 |  | [react/jsx-closing-tag-location](docs/rules/jsx-closing-tag-location.md) | Enforce closing tag location for multiline JSX |
+|  | 🔧 |  | [react/jsx-curly-brace-presence](docs/rules/jsx-curly-brace-presence.md) | Disallow unnecessary JSX expressions when literals alone are sufficient or enforce JSX expressions on literals in JSX children or attributes |
+|  | 🔧 |  | [react/jsx-curly-newline](docs/rules/jsx-curly-newline.md) | Enforce consistent linebreaks in curly braces in JSX attributes and expressions |
+|  | 🔧 |  | [react/jsx-curly-spacing](docs/rules/jsx-curly-spacing.md) | Enforce or disallow spaces inside of curly braces in JSX attributes and expressions |
+|  | 🔧 |  | [react/jsx-equals-spacing](docs/rules/jsx-equals-spacing.md) | Enforce or disallow spaces around equal signs in JSX attributes |
+|  |  |  | [react/jsx-filename-extension](docs/rules/jsx-filename-extension.md) | Disallow file extensions that may contain JSX |
+|  | 🔧 |  | [react/jsx-first-prop-new-line](docs/rules/jsx-first-prop-new-line.md) | Enforce proper position of the first property in JSX |
 |  | 🔧 |  | [react/jsx-fragments](docs/rules/jsx-fragments.md) | Enforce shorthand or standard form for React fragments |
 |  |  |  | [react/jsx-handler-names](docs/rules/jsx-handler-names.md) | Enforce event handler naming conventions in JSX |
-|  | 🔧 |  | [react/jsx-indent](docs/rules/jsx-indent.md) | Validate JSX indentation |
-|  | 🔧 |  | [react/jsx-indent-props](docs/rules/jsx-indent-props.md) | Validate props indentation in JSX |
-| ✔ |  |  | [react/jsx-key](docs/rules/jsx-key.md) | Report missing `key` props in iterators/collection literals |
-|  |  |  | [react/jsx-max-depth](docs/rules/jsx-max-depth.md) | Validate JSX maximum depth |
-|  | 🔧 |  | [react/jsx-max-props-per-line](docs/rules/jsx-max-props-per-line.md) | Limit maximum of props on a single line in JSX |
+|  | 🔧 |  | [react/jsx-indent](docs/rules/jsx-indent.md) | Enforce JSX indentation |
+|  | 🔧 |  | [react/jsx-indent-props](docs/rules/jsx-indent-props.md) | Enforce props indentation in JSX |
+| ✔ |  |  | [react/jsx-key](docs/rules/jsx-key.md) | Disallow missing `key` props in iterators/collection literals |
+|  |  |  | [react/jsx-max-depth](docs/rules/jsx-max-depth.md) | Enforce JSX maximum depth |
+|  | 🔧 |  | [react/jsx-max-props-per-line](docs/rules/jsx-max-props-per-line.md) | Enforce maximum of props on a single line in JSX |
 |  | 🔧 |  | [react/jsx-newline](docs/rules/jsx-newline.md) | Require or prevent a new line after jsx elements and expressions. |
-|  |  |  | [react/jsx-no-bind](docs/rules/jsx-no-bind.md) | Prevents usage of Function.prototype.bind and arrow functions in React component props |
-| ✔ |  |  | [react/jsx-no-comment-textnodes](docs/rules/jsx-no-comment-textnodes.md) | Comments inside children section of tag should be placed inside braces |
-|  |  |  | [react/jsx-no-constructed-context-values](docs/rules/jsx-no-constructed-context-values.md) | Prevents JSX context provider values from taking values that will cause needless rerenders. |
-| ✔ |  |  | [react/jsx-no-duplicate-props](docs/rules/jsx-no-duplicate-props.md) | Enforce no duplicate props |
-|  | 🔧 |  | [react/jsx-no-leaked-render](docs/rules/jsx-no-leaked-render.md) | Prevent problematic leaked values from being rendered |
-|  |  |  | [react/jsx-no-literals](docs/rules/jsx-no-literals.md) | Prevent using string literals in React component definition |
-|  |  |  | [react/jsx-no-script-url](docs/rules/jsx-no-script-url.md) | Forbid `javascript:` URLs |
-| ✔ | 🔧 |  | [react/jsx-no-target-blank](docs/rules/jsx-no-target-blank.md) | Forbid `target="_blank"` attribute without `rel="noreferrer"` |
+|  |  |  | [react/jsx-no-bind](docs/rules/jsx-no-bind.md) | Disallow `.bind()` or arrow functions in JSX props |
+| ✔ |  |  | [react/jsx-no-comment-textnodes](docs/rules/jsx-no-comment-textnodes.md) | Disallow comments from being inserted as text nodes |
+|  |  |  | [react/jsx-no-constructed-context-values](docs/rules/jsx-no-constructed-context-values.md) | Disallows JSX context provider values from taking values that will cause needless rerenders |
+| ✔ |  |  | [react/jsx-no-duplicate-props](docs/rules/jsx-no-duplicate-props.md) | Disallow duplicate properties in JSX |
+|  | 🔧 |  | [react/jsx-no-leaked-render](docs/rules/jsx-no-leaked-render.md) | Disallow problematic leaked values from being rendered |
+|  |  |  | [react/jsx-no-literals](docs/rules/jsx-no-literals.md) | Disallow usage of string literals in JSX |
+|  |  |  | [react/jsx-no-script-url](docs/rules/jsx-no-script-url.md) | Disallow usage of `javascript:` URLs |
+| ✔ | 🔧 |  | [react/jsx-no-target-blank](docs/rules/jsx-no-target-blank.md) | Disallow `target="_blank"` attribute without `rel="noreferrer"` |
 | ✔ |  |  | [react/jsx-no-undef](docs/rules/jsx-no-undef.md) | Disallow undeclared variables in JSX |
 |  | 🔧 |  | [react/jsx-no-useless-fragment](docs/rules/jsx-no-useless-fragment.md) | Disallow unnecessary fragments |
-|  | 🔧 |  | [react/jsx-one-expression-per-line](docs/rules/jsx-one-expression-per-line.md) | Limit to one expression per line in JSX |
+|  | 🔧 |  | [react/jsx-one-expression-per-line](docs/rules/jsx-one-expression-per-line.md) | Require one JSX element per line |
 |  |  |  | [react/jsx-pascal-case](docs/rules/jsx-pascal-case.md) | Enforce PascalCase for user-defined JSX components |
 |  | 🔧 |  | [react/jsx-props-no-multi-spaces](docs/rules/jsx-props-no-multi-spaces.md) | Disallow multiple spaces between inline JSX props |
-|  |  |  | [react/jsx-props-no-spreading](docs/rules/jsx-props-no-spreading.md) | Prevent JSX prop spreading |
-|  |  |  | [react/jsx-sort-default-props](docs/rules/jsx-sort-default-props.md) | Enforce default props alphabetical sorting |
+|  |  |  | [react/jsx-props-no-spreading](docs/rules/jsx-props-no-spreading.md) | Disallow JSX prop spreading |
+|  |  |  | [react/jsx-sort-default-props](docs/rules/jsx-sort-default-props.md) | Enforce defaultProps declarations alphabetical sorting |
 |  | 🔧 |  | [react/jsx-sort-props](docs/rules/jsx-sort-props.md) | Enforce props alphabetical sorting |
-|  | 🔧 |  | [react/jsx-space-before-closing](docs/rules/jsx-space-before-closing.md) | Validate spacing before closing bracket in JSX |
-|  | 🔧 |  | [react/jsx-tag-spacing](docs/rules/jsx-tag-spacing.md) | Validate whitespace in and around the JSX opening and closing brackets |
-| ✔ |  |  | [react/jsx-uses-react](docs/rules/jsx-uses-react.md) | Prevent React to be marked as unused |
-| ✔ |  |  | [react/jsx-uses-vars](docs/rules/jsx-uses-vars.md) | Prevent variables used in JSX to be marked as unused |
-|  | 🔧 |  | [react/jsx-wrap-multilines](docs/rules/jsx-wrap-multilines.md) | Prevent missing parentheses around multilines JSX |
+|  | 🔧 |  | [react/jsx-space-before-closing](docs/rules/jsx-space-before-closing.md) | Enforce spacing before closing bracket in JSX |
+|  | 🔧 |  | [react/jsx-tag-spacing](docs/rules/jsx-tag-spacing.md) | Enforce whitespace in and around the JSX opening and closing brackets |
+| ✔ |  |  | [react/jsx-uses-react](docs/rules/jsx-uses-react.md) | Disallow React to be incorrectly marked as unused |
+| ✔ |  |  | [react/jsx-uses-vars](docs/rules/jsx-uses-vars.md) | Disallow variables used in JSX to be incorrectly marked as unused |
+|  | 🔧 |  | [react/jsx-wrap-multilines](docs/rules/jsx-wrap-multilines.md) | Disallow missing parentheses around multiline JSX |
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Other useful plugins

--- a/docs/rules/button-has-type.md
+++ b/docs/rules/button-has-type.md
@@ -1,4 +1,4 @@
-# Prevent usage of `button` elements without an explicit `type` attribute (react/button-has-type)
+# Disallow usage of `button` elements without an explicit `type` attribute (react/button-has-type)
 
 The default value of `type` attribute for `button` HTML element is `"submit"` which is often not the desired behavior and may lead to unexpected page reloads.
 This rules enforces an explicit `type` attribute for all the `button` elements and checks that its value is valid per spec (i.e., is one of `"button"`, `"submit"`, and `"reset"`).

--- a/docs/rules/display-name.md
+++ b/docs/rules/display-name.md
@@ -1,4 +1,4 @@
-# Prevent missing displayName in a React component definition (react/display-name)
+# Disallow missing displayName in a React component definition (react/display-name)
 
 DisplayName allows you to name your component. This name is used by React in debugging messages.
 

--- a/docs/rules/forbid-component-props.md
+++ b/docs/rules/forbid-component-props.md
@@ -1,4 +1,4 @@
-# Forbid certain props on Components (react/forbid-component-props)
+# Disallow certain props on components (react/forbid-component-props)
 
 By default this rule prevents passing of [props that add lots of complexity](https://medium.com/brigade-engineering/don-t-pass-css-classes-between-components-e9f7ab192785) (`className`, `style`) to Components. This rule only applies to Components (e.g. `<Foo />`) and not DOM nodes (e.g. `<div />`). The list of forbidden props can be customized with the `forbid` option.
 

--- a/docs/rules/forbid-dom-props.md
+++ b/docs/rules/forbid-dom-props.md
@@ -1,4 +1,4 @@
-# Forbid certain props on DOM Nodes (react/forbid-dom-props)
+# Disallow certain props on DOM Nodes (react/forbid-dom-props)
 
 This rule prevents passing of props to elements. This rule only applies to DOM Nodes (e.g. `<div />`) and not Components (e.g. `<Component />`).
 The list of forbidden props can be customized with the `forbid` option.

--- a/docs/rules/forbid-elements.md
+++ b/docs/rules/forbid-elements.md
@@ -1,4 +1,4 @@
-# Forbid certain elements (react/forbid-elements)
+# Disallow certain elements (react/forbid-elements)
 
 You may want to forbid usage of certain elements in favor of others, (e.g. forbid all `<div />` and use `<Box />` instead). This rule allows you to configure a list of forbidden elements and to specify their desired replacements.
 

--- a/docs/rules/forbid-foreign-prop-types.md
+++ b/docs/rules/forbid-foreign-prop-types.md
@@ -1,4 +1,4 @@
-# Forbid foreign propTypes (react/forbid-foreign-prop-types)
+# Disallow using another component's propTypes (react/forbid-foreign-prop-types)
 
 This rule forbids using another component's prop types unless they are explicitly imported/exported. This allows people who want to use [babel-plugin-transform-react-remove-prop-types](https://github.com/oliviertassinari/babel-plugin-transform-react-remove-prop-types) to remove propTypes from their components in production builds, to do so safely.
 

--- a/docs/rules/forbid-prop-types.md
+++ b/docs/rules/forbid-prop-types.md
@@ -1,4 +1,4 @@
-# Forbid certain propTypes (react/forbid-prop-types)
+# Disallow certain propTypes (react/forbid-prop-types)
 
 By default this rule prevents vague prop types with more specific alternatives available (`any`, `array`, `object`), but any prop type can be disabled if desired. The defaults are chosen because they have obvious replacements. `any` should be replaced with, well, anything. `array` and `object` can be replaced with `arrayOf` and `shape`, respectively.
 

--- a/docs/rules/jsx-boolean-value.md
+++ b/docs/rules/jsx-boolean-value.md
@@ -2,9 +2,13 @@
 
 🔧 This rule is automatically fixable using the `--fix` [flag](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) on the command line.
 
-[When using a boolean attribute in JSX](https://facebook.github.io/react/docs/jsx-in-depth.html#boolean-attributes), you can set the attribute value to `true` or omit the value. This rule will enforce one or the other to keep consistency in your code.
+[When using a boolean attribute in JSX](https://facebook.github.io/react/docs/jsx-in-depth.html#boolean-attributes), you can set the attribute value to `true` or omit the value.
 
 ## Rule Details
+
+This rule will enforce one or the other to keep consistency in your code.
+
+## Rule Options
 
 This rule takes two arguments. If the first argument is `"always"` then it warns whenever an attribute is missing its value. If `"never"` then it warns if an attribute has a `true` value. The default value of this option is `"never"`.
 

--- a/docs/rules/jsx-child-element-spacing.md
+++ b/docs/rules/jsx-child-element-spacing.md
@@ -1,4 +1,4 @@
-# Enforce or disallow spaces inside of curly braces in JSX attributes and expressions. (react/jsx-child-element-spacing)
+# Enforce or disallow spaces inside of curly braces in JSX attributes and expressions (react/jsx-child-element-spacing)
 
 ## Rule Details
 

--- a/docs/rules/jsx-closing-bracket-location.md
+++ b/docs/rules/jsx-closing-bracket-location.md
@@ -1,4 +1,4 @@
-# Validate closing bracket location in JSX (react/jsx-closing-bracket-location)
+# Enforce closing bracket location in JSX (react/jsx-closing-bracket-location)
 
 🔧 This rule is automatically fixable using the `--fix` [flag](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) on the command line.
 

--- a/docs/rules/jsx-closing-tag-location.md
+++ b/docs/rules/jsx-closing-tag-location.md
@@ -1,4 +1,4 @@
-# Validate closing tag location in JSX (react/jsx-closing-tag-location)
+# Enforce closing tag location for multiline JSX (react/jsx-closing-tag-location)
 
 🔧 This rule is automatically fixable using the `--fix` [flag](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) on the command line.
 

--- a/docs/rules/jsx-curly-brace-presence.md
+++ b/docs/rules/jsx-curly-brace-presence.md
@@ -1,4 +1,4 @@
-# Enforce curly braces or disallow unnecessary curly braces in JSX props and/or children. (react/jsx-curly-brace-presence)
+# Disallow unnecessary JSX expressions when literals alone are sufficient or enforce JSX expressions on literals in JSX children or attributes (react/jsx-curly-brace-presence)
 
 🔧 This rule is automatically fixable using the `--fix` [flag](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) on the command line.
 

--- a/docs/rules/jsx-curly-newline.md
+++ b/docs/rules/jsx-curly-newline.md
@@ -1,4 +1,4 @@
-# Enforce linebreaks in curly braces in JSX attributes and expressions. (react/jsx-curly-newline)
+# Enforce consistent linebreaks in curly braces in JSX attributes and expressions (react/jsx-curly-newline)
 
 🔧 This rule is automatically fixable using the `--fix` [flag](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) on the command line.
 

--- a/docs/rules/jsx-curly-spacing.md
+++ b/docs/rules/jsx-curly-spacing.md
@@ -1,4 +1,4 @@
-# Enforce or disallow spaces inside of curly braces in JSX attributes and expressions. (react/jsx-curly-spacing)
+# Enforce or disallow spaces inside of curly braces in JSX attributes and expressions (react/jsx-curly-spacing)
 
 🔧 This rule is automatically fixable using the `--fix` [flag](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) on the command line.
 

--- a/docs/rules/jsx-equals-spacing.md
+++ b/docs/rules/jsx-equals-spacing.md
@@ -1,4 +1,4 @@
-# Enforce or disallow spaces around equal signs in JSX attributes. (react/jsx-equals-spacing)
+# Enforce or disallow spaces around equal signs in JSX attributes (react/jsx-equals-spacing)
 
 🔧 This rule is automatically fixable using the `--fix` [flag](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) on the command line.
 
@@ -8,7 +8,7 @@ Some style guides require or disallow spaces around equal signs.
 
 This rule will enforce consistency of spacing around equal signs in JSX attributes, by requiring or disallowing one or more spaces before and after `=`.
 
-### Options
+## Rule Options
 
 There are two options for the rule:
 
@@ -21,7 +21,7 @@ Depending on your coding conventions, you can choose either option by specifying
 "react/jsx-equals-spacing": [2, "always"]
 ```
 
-#### never
+### never
 
 Examples of **incorrect** code for this rule, when configured with `"never"`:
 
@@ -39,7 +39,7 @@ Examples of **correct** code for this rule, when configured with `"never"`:
 <Hello {...props} />;
 ```
 
-#### always
+### always
 
 Examples of **incorrect** code for this rule, when configured with `"always"`:
 

--- a/docs/rules/jsx-filename-extension.md
+++ b/docs/rules/jsx-filename-extension.md
@@ -1,4 +1,4 @@
-# Restrict file extensions that may contain JSX (react/jsx-filename-extension)
+# Disallow file extensions that may contain JSX (react/jsx-filename-extension)
 
 ## Rule Details
 

--- a/docs/rules/jsx-first-prop-new-line.md
+++ b/docs/rules/jsx-first-prop-new-line.md
@@ -1,4 +1,4 @@
-# Configure the position of the first property (react/jsx-first-prop-new-line)
+# Enforce proper position of the first property in JSX (react/jsx-first-prop-new-line)
 
 🔧 This rule is automatically fixable using the `--fix` [flag](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) on the command line.
 

--- a/docs/rules/jsx-fragments.md
+++ b/docs/rules/jsx-fragments.md
@@ -2,7 +2,11 @@
 
 🔧 This rule is automatically fixable using the `--fix` [flag](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) on the command line.
 
-In JSX, a React fragment is created either with `<React.Fragment>...</React.Fragment>`, or, using the shorthand syntax, `<>...</>`. This rule allows you to enforce one way or the other.
+In JSX, a React fragment is created either with `<React.Fragment>...</React.Fragment>`, or, using the shorthand syntax, `<>...</>`.
+
+## Rule Details
+
+This rule allows you to enforce one way or the other.
 
 Support for fragments was added in React v16.2, so the rule will warn on either of these forms if an older React version is specified in [shared settings][shared_settings].
 

--- a/docs/rules/jsx-indent-props.md
+++ b/docs/rules/jsx-indent-props.md
@@ -1,4 +1,4 @@
-# Validate props indentation in JSX (react/jsx-indent-props)
+# Enforce props indentation in JSX (react/jsx-indent-props)
 
 🔧 This rule is automatically fixable using the `--fix` [flag](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) on the command line.
 

--- a/docs/rules/jsx-indent.md
+++ b/docs/rules/jsx-indent.md
@@ -1,4 +1,4 @@
-# Validate JSX indentation (react/jsx-indent)
+# Enforce JSX indentation (react/jsx-indent)
 
 🔧 This rule is automatically fixable using the `--fix` [flag](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) on the command line.
 

--- a/docs/rules/jsx-key.md
+++ b/docs/rules/jsx-key.md
@@ -1,4 +1,4 @@
-# Detect missing `key` prop (react/jsx-key)
+# Disallow missing `key` props in iterators/collection literals (react/jsx-key)
 
 Warn if an element that likely requires a `key` prop--namely, one present in an
 array literal or an arrow function expression.

--- a/docs/rules/jsx-max-depth.md
+++ b/docs/rules/jsx-max-depth.md
@@ -1,4 +1,4 @@
-# Validate JSX maximum depth (react/jsx-max-depth)
+# Enforce JSX maximum depth (react/jsx-max-depth)
 
 This option validates a specific depth for JSX.
 

--- a/docs/rules/jsx-max-props-per-line.md
+++ b/docs/rules/jsx-max-props-per-line.md
@@ -1,4 +1,4 @@
-# Limit maximum of props on a single line in JSX (react/jsx-max-props-per-line)
+# Enforce maximum of props on a single line in JSX (react/jsx-max-props-per-line)
 
 🔧 This rule is automatically fixable using the `--fix` [flag](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) on the command line.
 

--- a/docs/rules/jsx-no-bind.md
+++ b/docs/rules/jsx-no-bind.md
@@ -1,4 +1,4 @@
-# No `.bind()` or Arrow Functions in JSX Props (react/jsx-no-bind)
+# Disallow `.bind()` or arrow functions in JSX props (react/jsx-no-bind)
 
 A `bind` call or [arrow function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions) in a JSX prop will create a brand new function on every single render. This is bad for performance, as it may cause unnecessary re-renders if a brand new function is passed as a prop to a component that uses reference equality check on the prop to determine if it should update.
 

--- a/docs/rules/jsx-no-comment-textnodes.md
+++ b/docs/rules/jsx-no-comment-textnodes.md
@@ -1,4 +1,4 @@
-# Prevent comments from being inserted as text nodes (react/jsx-no-comment-textnodes)
+# Disallow comments from being inserted as text nodes (react/jsx-no-comment-textnodes)
 
 This rule prevents comment strings (e.g. beginning with `//` or `/*`) from being accidentally
 injected as a text node in JSX statements.

--- a/docs/rules/jsx-no-constructed-context-values.md
+++ b/docs/rules/jsx-no-constructed-context-values.md
@@ -1,4 +1,4 @@
-# Prevent react contexts from taking non-stable values (react/jsx-no-constructed-context-values)
+# Disallows JSX context provider values from taking values that will cause needless rerenders (react/jsx-no-constructed-context-values)
 
 This rule prevents non-stable values (i.e. object identities) from being used as a value for `Context.Provider`.
 

--- a/docs/rules/jsx-no-duplicate-props.md
+++ b/docs/rules/jsx-no-duplicate-props.md
@@ -1,4 +1,4 @@
-# Prevent duplicate properties in JSX (react/jsx-no-duplicate-props)
+# Disallow duplicate properties in JSX (react/jsx-no-duplicate-props)
 
 Creating JSX elements with duplicate props can cause unexpected behavior in your application.
 

--- a/docs/rules/jsx-no-leaked-render.md
+++ b/docs/rules/jsx-no-leaked-render.md
@@ -1,4 +1,4 @@
-# Prevent problematic leaked values from being rendered (react/jsx-no-leaked-render)
+# Disallow problematic leaked values from being rendered (react/jsx-no-leaked-render)
 
 🔧 This rule is automatically fixable using the `--fix` [flag](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) on the command line.
 
@@ -139,7 +139,7 @@ const Component = ({ elements }) => {
 }
 ```
 
-### Options
+## Rule Options
 
 The supported options are:
 

--- a/docs/rules/jsx-no-literals.md
+++ b/docs/rules/jsx-no-literals.md
@@ -1,4 +1,4 @@
-# Prevent usage of string literals in JSX (react/jsx-no-literals)
+# Disallow usage of string literals in JSX (react/jsx-no-literals)
 
 There are a few scenarios where you want to avoid string literals in JSX. You may want to enforce consistency, reduce syntax highlighting issues, or ensure that strings are part of a translation system.
 

--- a/docs/rules/jsx-no-script-url.md
+++ b/docs/rules/jsx-no-script-url.md
@@ -1,4 +1,4 @@
-# Prevent usage of `javascript:` URLs (react/jsx-no-script-url)
+# Disallow usage of `javascript:` URLs (react/jsx-no-script-url)
 
 **In React 16.9** any URLs starting with `javascript:` [scheme](https://wiki.whatwg.org/wiki/URL_schemes#javascript:_URLs) log a warning.
 React considers the pattern as a dangerous attack surface, see [details](https://reactjs.org/blog/2019/08/08/react-v16.9.0.html#deprecating-javascript-urls).

--- a/docs/rules/jsx-no-target-blank.md
+++ b/docs/rules/jsx-no-target-blank.md
@@ -1,4 +1,4 @@
-# Prevent usage of unsafe `target='_blank'` (react/jsx-no-target-blank)
+# Disallow `target="_blank"` attribute without `rel="noreferrer"` (react/jsx-no-target-blank)
 
 🔧 This rule is automatically fixable using the `--fix` [flag](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) on the command line.
 

--- a/docs/rules/jsx-one-expression-per-line.md
+++ b/docs/rules/jsx-one-expression-per-line.md
@@ -1,4 +1,4 @@
-# One JSX Element Per Line (react/jsx-one-expression-per-line)
+# Require one JSX element per line (react/jsx-one-expression-per-line)
 
 🔧 This rule is automatically fixable using the `--fix` [flag](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) on the command line.
 

--- a/docs/rules/jsx-props-no-spreading.md
+++ b/docs/rules/jsx-props-no-spreading.md
@@ -1,4 +1,4 @@
-# Disallow JSX props spreading (react/jsx-props-no-spreading)
+# Disallow JSX prop spreading (react/jsx-props-no-spreading)
 
 Enforces that there is no spreading for any JSX attribute. This enhances readability of code by being more explicit about what props are received by the component. It is also good for maintainability by avoiding passing unintentional extra props and allowing react to emit warnings when invalid HTML props are passed to HTML elements.
 

--- a/docs/rules/jsx-space-before-closing.md
+++ b/docs/rules/jsx-space-before-closing.md
@@ -1,4 +1,4 @@
-# Validate spacing before closing bracket in JSX (react/jsx-space-before-closing)
+# Enforce spacing before closing bracket in JSX (react/jsx-space-before-closing)
 
 🔧 This rule is automatically fixable using the `--fix` [flag](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) on the command line.
 
@@ -9,6 +9,8 @@ Enforce or forbid spaces before the closing bracket of self-closing JSX elements
 ## Rule Details
 
 This rule checks if there is one or more spaces before the closing bracket of self-closing JSX elements.
+
+## Rule Options
 
 This rule takes one argument. If it is `"always"` then it warns whenever a space is missing before the closing bracket. If `"never"` then it warns if a space is present before the closing bracket. The default value of this option is `"always"`.
 

--- a/docs/rules/jsx-tag-spacing.md
+++ b/docs/rules/jsx-tag-spacing.md
@@ -1,4 +1,4 @@
-# Validate whitespace in and around the JSX opening and closing brackets (react/jsx-tag-spacing)
+# Enforce whitespace in and around the JSX opening and closing brackets (react/jsx-tag-spacing)
 
 🔧 This rule is automatically fixable using the `--fix` [flag](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) on the command line.
 
@@ -7,6 +7,8 @@ Enforce or forbid spaces after the opening bracket, before the closing bracket, 
 ## Rule Details
 
 This rule checks the whitespace inside and surrounding the JSX syntactic elements.
+
+## Rule Options
 
 This rule takes one argument, an object with 4 possible keys: `closingSlash`, `beforeSelfClosing`, `afterOpening`, and `beforeClosing`. Each key can receive the value `"allow"` to disable that specific check.
 

--- a/docs/rules/jsx-uses-react.md
+++ b/docs/rules/jsx-uses-react.md
@@ -1,4 +1,4 @@
-# Prevent React to be incorrectly marked as unused (react/jsx-uses-react)
+# Disallow React to be incorrectly marked as unused (react/jsx-uses-react)
 
 JSX expands to a call to `React.createElement`, a file which includes `React`
 but only uses JSX should consider the `React` variable as used.

--- a/docs/rules/jsx-uses-vars.md
+++ b/docs/rules/jsx-uses-vars.md
@@ -1,4 +1,4 @@
-# Prevent variables used in JSX to be incorrectly marked as unused (react/jsx-uses-vars)
+# Disallow variables used in JSX to be incorrectly marked as unused (react/jsx-uses-vars)
 
 Since 0.17.0 the `eslint` `no-unused-vars` rule does not detect variables used in JSX ([see details](https://eslint.org/blog/2015/03/eslint-0.17.0-released#changes-to-jsxreact-handling)). This rule will find variables used in JSX and mark them as used.
 

--- a/docs/rules/jsx-wrap-multilines.md
+++ b/docs/rules/jsx-wrap-multilines.md
@@ -1,4 +1,4 @@
-# Prevent missing parentheses around multiline JSX (react/jsx-wrap-multilines)
+# Disallow missing parentheses around multiline JSX (react/jsx-wrap-multilines)
 
 🔧 This rule is automatically fixable using the `--fix` [flag](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) on the command line.
 
@@ -21,6 +21,8 @@ This rule optionally takes a second parameter in the form of an object, containi
 ```
 
 Note: conditions are checked by default in declarations or assignments.
+
+## Rule Options
 
 Examples of **incorrect** code for this rule, when configured with `parens` or `parens-new-line`:
 

--- a/docs/rules/no-access-state-in-setstate.md
+++ b/docs/rules/no-access-state-in-setstate.md
@@ -1,9 +1,14 @@
-# Prevent using this.state within a this.setState (react/no-access-state-in-setstate)
+# Disallow when this.state is accessed within setState (react/no-access-state-in-setstate)
+
+Usage of `this.state` inside `setState` calls might result in errors when two state calls are called in batch and thus referencing old state and not the current state.
+
+## Rule Details
 
 This rule should prevent usage of `this.state` inside `setState` calls.
-Such usage of `this.state` might result in errors when two state calls are
-called in batch and thus referencing old state and not the current
-state. An example can be an increment function:
+
+## Examples
+
+An example can be an increment function:
 
 ```javascript
 function increment() {

--- a/docs/rules/no-adjacent-inline-elements.md
+++ b/docs/rules/no-adjacent-inline-elements.md
@@ -1,4 +1,4 @@
-# Prevent adjacent inline elements not separated by whitespace. (react/no-adjacent-inline-elements)
+# Disallow adjacent inline elements not separated by whitespace. (react/no-adjacent-inline-elements)
 
 Adjacent inline elements not separated by whitespace will bump up against each
 other when viewed in an unstyled manner, which usually isn't desirable.

--- a/docs/rules/no-array-index-key.md
+++ b/docs/rules/no-array-index-key.md
@@ -1,4 +1,4 @@
-# Prevent usage of Array index in keys (react/no-array-index-key)
+# Disallow usage of Array index in keys (react/no-array-index-key)
 
 Warn if an element uses an Array index in its `key`.
 

--- a/docs/rules/no-children-prop.md
+++ b/docs/rules/no-children-prop.md
@@ -1,4 +1,4 @@
-# Prevent passing of children as props (react/no-children-prop)
+# Disallow passing of children as props (react/no-children-prop)
 
 Children should always be actual children, not passed in as a prop.
 

--- a/docs/rules/no-danger-with-children.md
+++ b/docs/rules/no-danger-with-children.md
@@ -1,4 +1,4 @@
-# Prevent problem with children and props.dangerouslySetInnerHTML (react/no-danger-with-children)
+# Disallow when a DOM element is using both children and dangerouslySetInnerHTML (react/no-danger-with-children)
 
 This rule helps prevent problems caused by using children and the dangerouslySetInnerHTML prop at the same time.
 React will throw a warning if this rule is ignored.

--- a/docs/rules/no-danger.md
+++ b/docs/rules/no-danger.md
@@ -1,4 +1,4 @@
-# Prevent usage of dangerous JSX properties (react/no-danger)
+# Disallow usage of dangerous JSX properties (react/no-danger)
 
 Dangerous properties in React are those whose behavior is known to be a common source of application vulnerabilities. The properties names clearly indicate they are dangerous and should be avoided unless great care is taken.
 

--- a/docs/rules/no-deprecated.md
+++ b/docs/rules/no-deprecated.md
@@ -1,4 +1,4 @@
-# Prevent usage of deprecated methods (react/no-deprecated)
+# Disallow usage of deprecated methods (react/no-deprecated)
 
 Several methods are deprecated between React versions. This rule will warn you if you try to use a deprecated method. Use the [shared settings](/README.md#configuration) to specify the React version.
 

--- a/docs/rules/no-did-mount-set-state.md
+++ b/docs/rules/no-did-mount-set-state.md
@@ -1,4 +1,4 @@
-# Prevent usage of setState in componentDidMount (react/no-did-mount-set-state)
+# Disallow usage of setState in componentDidMount (react/no-did-mount-set-state)
 
 Updating the state after a component mount will trigger a second `render()` call and can lead to property/layout thrashing.
 

--- a/docs/rules/no-did-update-set-state.md
+++ b/docs/rules/no-did-update-set-state.md
@@ -1,4 +1,4 @@
-# Prevent usage of setState in componentDidUpdate (react/no-did-update-set-state)
+# Disallow usage of setState in componentDidUpdate (react/no-did-update-set-state)
 
 Updating the state after a component update will trigger a second `render()` call and can lead to property/layout thrashing.
 

--- a/docs/rules/no-direct-mutation-state.md
+++ b/docs/rules/no-direct-mutation-state.md
@@ -1,4 +1,4 @@
-# Prevent direct mutation of this.state (react/no-direct-mutation-state)
+# Disallow direct mutation of this.state (react/no-direct-mutation-state)
 
 NEVER mutate `this.state` directly, as calling `setState()` afterwards may replace
 the mutation you made. Treat `this.state` as if it were immutable.

--- a/docs/rules/no-find-dom-node.md
+++ b/docs/rules/no-find-dom-node.md
@@ -1,4 +1,4 @@
-# Prevent usage of findDOMNode (react/no-find-dom-node)
+# Disallow usage of findDOMNode (react/no-find-dom-node)
 
 Facebook will eventually deprecate `findDOMNode` as it blocks certain improvements in React in the future.
 

--- a/docs/rules/no-invalid-html-attribute.md
+++ b/docs/rules/no-invalid-html-attribute.md
@@ -1,4 +1,4 @@
-# Prevent usage of invalid attributes (react/no-invalid-html-attribute)
+# Disallow usage of invalid attributes (react/no-invalid-html-attribute)
 
 🔧 This rule is automatically fixable using the `--fix` [flag](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) on the command line.
 

--- a/docs/rules/no-is-mounted.md
+++ b/docs/rules/no-is-mounted.md
@@ -1,4 +1,4 @@
-# Prevent usage of isMounted (react/no-is-mounted)
+# Disallow usage of isMounted (react/no-is-mounted)
 
 [`isMounted` is an anti-pattern][anti-pattern], is not available when using ES6 classes, and it is on its way to being officially deprecated.
 

--- a/docs/rules/no-multi-comp.md
+++ b/docs/rules/no-multi-comp.md
@@ -1,4 +1,4 @@
-# Prevent multiple component definition per file (react/no-multi-comp)
+# Disallow multiple component definition per file (react/no-multi-comp)
 
 Declaring only one component per file improves readability and reusability of components.
 

--- a/docs/rules/no-redundant-should-component-update.md
+++ b/docs/rules/no-redundant-should-component-update.md
@@ -1,4 +1,4 @@
-# Prevent usage of shouldComponentUpdate when extending React.PureComponent (react/no-redundant-should-component-update)
+# Disallow usage of shouldComponentUpdate when extending React.PureComponent (react/no-redundant-should-component-update)
 
 Warns if you have `shouldComponentUpdate` defined when defining a component that extends React.PureComponent.
 While having `shouldComponentUpdate` will still work, it becomes pointless to extend PureComponent.

--- a/docs/rules/no-render-return-value.md
+++ b/docs/rules/no-render-return-value.md
@@ -1,4 +1,4 @@
-# Prevent usage of the return value of ReactDOM.render (react/no-render-return-value)
+# Disallow usage of the return value of ReactDOM.render (react/no-render-return-value)
 
 > `ReactDOM.render()` currently returns a reference to the root `ReactComponent` instance. However, using this return value is legacy and should be avoided because future versions of React may render components asynchronously in some cases. If you need a reference to the root `ReactComponent` instance, the preferred solution is to attach a [callback ref](https://reactjs.org/docs/refs-and-the-dom.html#callback-refs) to the root element.
 

--- a/docs/rules/no-set-state.md
+++ b/docs/rules/no-set-state.md
@@ -1,4 +1,4 @@
-# Prevent usage of setState (react/no-set-state)
+# Disallow usage of setState (react/no-set-state)
 
 When using an architecture that separates your application state from your UI components (e.g. Flux), it may be desirable to forbid the use of local component state. This rule is especially helpful in read-only applications (that don't use forms), since local component state should rarely be necessary in such cases.
 

--- a/docs/rules/no-string-refs.md
+++ b/docs/rules/no-string-refs.md
@@ -1,4 +1,4 @@
-# Prevent using string references (react/no-string-refs)
+# Disallow using string references (react/no-string-refs)
 
 Currently, two ways are supported by React to refer to components. The first way, providing a string identifier, is now considered legacy in the official documentation. The documentation now prefers a second method -- referring to components by setting a property on the `this` object in the reference callback.
 

--- a/docs/rules/no-this-in-sfc.md
+++ b/docs/rules/no-this-in-sfc.md
@@ -1,4 +1,4 @@
-# Prevent `this` from being used in stateless functional components (react/no-this-in-sfc)
+# Disallow `this` from being used in stateless functional components (react/no-this-in-sfc)
 
 In React, there are two styles of component. One is a class component: `class Foo extends React.Component {...}`, which accesses its props, context, and state as properties of `this`: `this.props.foo`, etc. The other are stateless functional components (SFCs): `function Foo(props, context) {...}`. As you can see, there's no `state` (hence the name - hooks do not change this), and the props and context are provided as its two functional arguments. In an SFC, state is usually best implements with a [React hook](https://reactjs.org/docs/hooks-overview.html) such as `React.useState()`.
 

--- a/docs/rules/no-typos.md
+++ b/docs/rules/no-typos.md
@@ -1,4 +1,4 @@
-# Prevents common typos (react/no-typos)
+# Disallow common typos (react/no-typos)
 
 Ensure no casing typos were made declaring static class properties and lifecycle methods.
 Checks that declared `propTypes`, `contextTypes` and `childContextTypes` is supported by [react-props](https://github.com/facebook/prop-types)

--- a/docs/rules/no-unescaped-entities.md
+++ b/docs/rules/no-unescaped-entities.md
@@ -1,4 +1,4 @@
-# Prevent invalid characters from appearing in markup (react/no-unescaped-entities)
+# Disallow unescaped HTML entities from appearing in markup (react/no-unescaped-entities)
 
 This rule prevents characters that you may have meant as JSX escape characters
 from being accidentally injected as a text node in JSX statements.

--- a/docs/rules/no-unknown-property.md
+++ b/docs/rules/no-unknown-property.md
@@ -1,4 +1,4 @@
-# Prevent usage of unknown DOM property (react/no-unknown-property)
+# Disallow usage of unknown DOM property (react/no-unknown-property)
 
 🔧 This rule is automatically fixable using the `--fix` [flag](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) on the command line.
 

--- a/docs/rules/no-unsafe.md
+++ b/docs/rules/no-unsafe.md
@@ -1,4 +1,4 @@
-# Prevent usage of unsafe lifecycle methods (react/no-unsafe)
+# Disallow usage of unsafe lifecycle methods (react/no-unsafe)
 
 Certain legacy lifecycle methods are [unsafe for use in async React applications][async_rendering] and cause warnings in [_strict mode_][strict_mode]. These also happen to be the lifecycles that cause the most [confusion within the React community][component_lifecycle_changes].
 

--- a/docs/rules/no-unstable-nested-components.md
+++ b/docs/rules/no-unstable-nested-components.md
@@ -1,4 +1,4 @@
-# Prevent creating unstable components inside components (react/no-unstable-nested-components)
+# Disallow creating unstable components inside components (react/no-unstable-nested-components)
 
 Creating components inside components without memoization leads to unstable components. The nested component and all its children are recreated during each re-render. Given stateful children of the nested component will lose their state on each re-render.
 

--- a/docs/rules/no-unused-class-component-methods.md
+++ b/docs/rules/no-unused-class-component-methods.md
@@ -1,4 +1,4 @@
-# Prevent declaring unused methods of component class (react/no-unused-class-component-methods)
+# Disallow declaring unused methods of component class (react/no-unused-class-component-methods)
 
 Warns you if you have defined a method or property but it is never being used anywhere.
 

--- a/docs/rules/no-unused-prop-types.md
+++ b/docs/rules/no-unused-prop-types.md
@@ -1,4 +1,4 @@
-# Prevent definitions of unused propTypes (react/no-unused-prop-types)
+# Disallow definitions of unused propTypes (react/no-unused-prop-types)
 
 Warns if a prop with a defined type isn't being used.
 

--- a/docs/rules/no-unused-state.md
+++ b/docs/rules/no-unused-state.md
@@ -1,4 +1,4 @@
-# Prevent definitions of unused state (react/no-unused-state)
+# Disallow definitions of unused state (react/no-unused-state)
 
 Warns you if you have defined a property on the state, but it is not being used anywhere.
 

--- a/docs/rules/no-will-update-set-state.md
+++ b/docs/rules/no-will-update-set-state.md
@@ -1,4 +1,4 @@
-# Prevent usage of setState in componentWillUpdate (react/no-will-update-set-state)
+# Disallow usage of setState in componentWillUpdate (react/no-will-update-set-state)
 
 Updating the state during the componentWillUpdate step can lead to indeterminate component state and is not allowed.
 

--- a/docs/rules/prefer-es6-class.md
+++ b/docs/rules/prefer-es6-class.md
@@ -1,6 +1,10 @@
 # Enforce ES5 or ES6 class for React Components (react/prefer-es6-class)
 
-React offers you two ways to create traditional components: using the ES5 `create-react-class` module or the new ES6 class system. This rule allows you to enforce one way or another.
+React offers you two ways to create traditional components: using the ES5 `create-react-class` module or the new ES6 class system.
+
+## Rule Details
+
+This rule allows you to enforce one way or another.
 
 ## Rule Options
 

--- a/docs/rules/prefer-stateless-function.md
+++ b/docs/rules/prefer-stateless-function.md
@@ -1,4 +1,4 @@
-# Enforce stateless React Components to be written as a pure function (react/prefer-stateless-function)
+# Enforce stateless components to be written as a pure function (react/prefer-stateless-function)
 
 Stateless functional components are simpler than class based components and will benefit from future React performance optimizations specific to these components.
 

--- a/docs/rules/prop-types.md
+++ b/docs/rules/prop-types.md
@@ -1,4 +1,4 @@
-# Prevent missing props validation in a React component definition (react/prop-types)
+# Disallow missing props validation in a React component definition (react/prop-types)
 
 Defining types for component props improves reusability of your components by
 validating received data. It can warn other developers if they make a mistake while reusing the component with improper data type.

--- a/docs/rules/react-in-jsx-scope.md
+++ b/docs/rules/react-in-jsx-scope.md
@@ -1,4 +1,4 @@
-# Prevent missing React when using JSX (react/react-in-jsx-scope)
+# Disallow missing React when using JSX (react/react-in-jsx-scope)
 
 When using JSX, `<a />` expands to `React.createElement("a")`. Therefore the `React` variable must be in scope.
 

--- a/docs/rules/self-closing-comp.md
+++ b/docs/rules/self-closing-comp.md
@@ -1,4 +1,4 @@
-# Prevent extra closing tags for components without children (react/self-closing-comp)
+# Disallow extra closing tags for components without children (react/self-closing-comp)
 
 🔧 This rule is automatically fixable using the `--fix` [flag](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) on the command line.
 

--- a/docs/rules/state-in-constructor.md
+++ b/docs/rules/state-in-constructor.md
@@ -1,4 +1,6 @@
-# Enforce state initialization style (react/state-in-constructor)
+# Enforce class component state initialization style (react/state-in-constructor)
+
+## Rule Details
 
 This rule will enforce the state initialization style to be either in a constructor or with a class property.
 

--- a/docs/rules/static-property-placement.md
+++ b/docs/rules/static-property-placement.md
@@ -124,7 +124,7 @@ MyComponent.defaultProps = { /*...*/ };
 MyComponent.propTypes = { /*...*/ };
 ```
 
-### Options
+## Rule Options
 
 ```
 ...

--- a/docs/rules/style-prop-object.md
+++ b/docs/rules/style-prop-object.md
@@ -1,4 +1,4 @@
-# Enforce style prop value being an object (react/style-prop-object)
+# Enforce style prop value is an object (react/style-prop-object)
 
 Require that the value of the prop `style` be an object or a variable that is
 an object.

--- a/docs/rules/void-dom-elements-no-children.md
+++ b/docs/rules/void-dom-elements-no-children.md
@@ -1,4 +1,4 @@
-# Prevent void DOM elements (e.g. `<img />`, `<br />`) from receiving children (react/void-dom-elements-no-children)
+# Disallow void DOM elements (e.g. `<img />`, `<br />`) from receiving children (react/void-dom-elements-no-children)
 
 There are some HTML elements that are only self-closing (e.g. `img`, `br`, `hr`). These are collectively known as void DOM elements. If you try to give these children, React will give you a warning like:
 

--- a/lib/rules/button-has-type.js
+++ b/lib/rules/button-has-type.js
@@ -31,7 +31,7 @@ const messages = {
 module.exports = {
   meta: {
     docs: {
-      description: 'Forbid "button" element without an explicit "type" attribute',
+      description: 'Disallow usage of `button` elements without an explicit `type` attribute',
       category: 'Possible Errors',
       recommended: false,
       url: docsUrl('button-has-type'),

--- a/lib/rules/default-props-match-prop-types.js
+++ b/lib/rules/default-props-match-prop-types.js
@@ -22,7 +22,7 @@ const messages = {
 module.exports = {
   meta: {
     docs: {
-      description: 'Enforce all defaultProps are defined and not "required" in propTypes.',
+      description: 'Enforce all defaultProps have a corresponding non-required PropType',
       category: 'Best Practices',
       url: docsUrl('default-props-match-prop-types'),
     },

--- a/lib/rules/display-name.js
+++ b/lib/rules/display-name.js
@@ -26,7 +26,7 @@ const messages = {
 module.exports = {
   meta: {
     docs: {
-      description: 'Prevent missing displayName in a React component definition',
+      description: 'Disallow missing displayName in a React component definition',
       category: 'Best Practices',
       recommended: true,
       url: docsUrl('display-name'),

--- a/lib/rules/forbid-component-props.js
+++ b/lib/rules/forbid-component-props.js
@@ -25,7 +25,7 @@ const messages = {
 module.exports = {
   meta: {
     docs: {
-      description: 'Forbid certain props on components',
+      description: 'Disallow certain props on components',
       category: 'Best Practices',
       recommended: false,
       url: docsUrl('forbid-component-props'),

--- a/lib/rules/forbid-dom-props.js
+++ b/lib/rules/forbid-dom-props.js
@@ -40,7 +40,7 @@ const messages = {
 module.exports = {
   meta: {
     docs: {
-      description: 'Forbid certain props on DOM Nodes',
+      description: 'Disallow certain props on DOM Nodes',
       category: 'Best Practices',
       recommended: false,
       url: docsUrl('forbid-dom-props'),

--- a/lib/rules/forbid-elements.js
+++ b/lib/rules/forbid-elements.js
@@ -22,7 +22,7 @@ const messages = {
 module.exports = {
   meta: {
     docs: {
-      description: 'Forbid certain elements',
+      description: 'Disallow certain elements',
       category: 'Best Practices',
       recommended: false,
       url: docsUrl('forbid-elements'),

--- a/lib/rules/forbid-foreign-prop-types.js
+++ b/lib/rules/forbid-foreign-prop-types.js
@@ -16,7 +16,7 @@ const messages = {
 module.exports = {
   meta: {
     docs: {
-      description: 'Forbid using another component\'s propTypes',
+      description: 'Disallow using another component\'s propTypes',
       category: 'Best Practices',
       recommended: false,
       url: docsUrl('forbid-foreign-prop-types'),

--- a/lib/rules/forbid-prop-types.js
+++ b/lib/rules/forbid-prop-types.js
@@ -28,7 +28,7 @@ const messages = {
 module.exports = {
   meta: {
     docs: {
-      description: 'Forbid certain propTypes',
+      description: 'Disallow certain propTypes',
       category: 'Best Practices',
       recommended: false,
       url: docsUrl('forbid-prop-types'),

--- a/lib/rules/function-component-definition.js
+++ b/lib/rules/function-component-definition.js
@@ -118,7 +118,7 @@ const messages = {
 module.exports = {
   meta: {
     docs: {
-      description: 'Standardize the way function component get defined',
+      description: 'Enforce a specific function type for function components',
       category: 'Stylistic Issues',
       recommended: false,
       url: docsUrl('function-component-definition'),

--- a/lib/rules/hook-use-state.js
+++ b/lib/rules/hook-use-state.js
@@ -20,7 +20,7 @@ const messages = {
 module.exports = {
   meta: {
     docs: {
-      description: 'Ensure symmetric naming of useState hook value and setter variables',
+      description: 'Ensure destructuring and symmetric naming of useState hook value and setter variables',
       category: 'Best Practices',
       recommended: false,
       url: docsUrl('hook-use-state'),

--- a/lib/rules/jsx-child-element-spacing.js
+++ b/lib/rules/jsx-child-element-spacing.js
@@ -47,7 +47,7 @@ const messages = {
 module.exports = {
   meta: {
     docs: {
-      description: 'Ensures inline tags are not rendered without spaces between them',
+      description: 'Enforce or disallow spaces inside of curly braces in JSX attributes and expressions',
       category: 'Stylistic Issues',
       recommended: false,
       url: docsUrl('jsx-child-element-spacing'),
@@ -56,14 +56,7 @@ module.exports = {
 
     messages,
 
-    schema: [
-      {
-        type: 'object',
-        properties: {},
-        default: {},
-        additionalProperties: false,
-      },
-    ],
+    schema: [],
   },
   create(context) {
     const TEXT_FOLLOWING_ELEMENT_PATTERN = /^\s*\n\s*\S/;

--- a/lib/rules/jsx-closing-bracket-location.js
+++ b/lib/rules/jsx-closing-bracket-location.js
@@ -20,7 +20,7 @@ const messages = {
 module.exports = {
   meta: {
     docs: {
-      description: 'Validate closing bracket location in JSX',
+      description: 'Enforce closing bracket location in JSX',
       category: 'Stylistic Issues',
       recommended: false,
       url: docsUrl('jsx-closing-bracket-location'),

--- a/lib/rules/jsx-closing-tag-location.js
+++ b/lib/rules/jsx-closing-tag-location.js
@@ -21,7 +21,7 @@ const messages = {
 module.exports = {
   meta: {
     docs: {
-      description: 'Validate closing tag location for multiline JSX',
+      description: 'Enforce closing tag location for multiline JSX',
       category: 'Stylistic Issues',
       recommended: false,
       url: docsUrl('jsx-closing-tag-location'),

--- a/lib/rules/jsx-curly-brace-presence.js
+++ b/lib/rules/jsx-curly-brace-presence.js
@@ -39,7 +39,7 @@ const messages = {
 module.exports = {
   meta: {
     docs: {
-      description: 'Disallow unnecessary JSX expressions when literals alone are sufficient or enfore JSX expressions on literals in JSX children or attributes',
+      description: 'Disallow unnecessary JSX expressions when literals alone are sufficient or enforce JSX expressions on literals in JSX children or attributes',
       category: 'Stylistic Issues',
       recommended: false,
       url: docsUrl('jsx-curly-brace-presence'),

--- a/lib/rules/jsx-curly-newline.js
+++ b/lib/rules/jsx-curly-newline.js
@@ -46,7 +46,7 @@ module.exports = {
     type: 'layout',
 
     docs: {
-      description: 'Enforce consistent line breaks inside jsx curly',
+      description: 'Enforce consistent linebreaks in curly braces in JSX attributes and expressions',
       category: 'Stylistic Issues',
       recommended: false,
       url: docsUrl('jsx-curly-newline'),

--- a/lib/rules/jsx-curly-spacing.js
+++ b/lib/rules/jsx-curly-spacing.js
@@ -37,7 +37,7 @@ const messages = {
 module.exports = {
   meta: {
     docs: {
-      description: 'Enforce or disallow spaces inside of curly braces in JSX attributes',
+      description: 'Enforce or disallow spaces inside of curly braces in JSX attributes and expressions',
       category: 'Stylistic Issues',
       recommended: false,
       url: docsUrl('jsx-curly-spacing'),

--- a/lib/rules/jsx-equals-spacing.js
+++ b/lib/rules/jsx-equals-spacing.js
@@ -22,7 +22,7 @@ const messages = {
 module.exports = {
   meta: {
     docs: {
-      description: 'Disallow or enforce spaces around equal signs in JSX attributes',
+      description: 'Enforce or disallow spaces around equal signs in JSX attributes',
       category: 'Stylistic Issues',
       recommended: false,
       url: docsUrl('jsx-equals-spacing'),

--- a/lib/rules/jsx-filename-extension.js
+++ b/lib/rules/jsx-filename-extension.js
@@ -30,7 +30,7 @@ const messages = {
 module.exports = {
   meta: {
     docs: {
-      description: 'Restrict file extensions that may contain JSX',
+      description: 'Disallow file extensions that may contain JSX',
       category: 'Stylistic Issues',
       recommended: false,
       url: docsUrl('jsx-filename-extension'),

--- a/lib/rules/jsx-first-prop-new-line.js
+++ b/lib/rules/jsx-first-prop-new-line.js
@@ -20,7 +20,7 @@ const messages = {
 module.exports = {
   meta: {
     docs: {
-      description: 'Ensure proper position of the first property in JSX',
+      description: 'Enforce proper position of the first property in JSX',
       category: 'Stylistic Issues',
       recommended: false,
       url: docsUrl('jsx-first-prop-new-line'),

--- a/lib/rules/jsx-indent-props.js
+++ b/lib/rules/jsx-indent-props.js
@@ -45,7 +45,7 @@ const messages = {
 module.exports = {
   meta: {
     docs: {
-      description: 'Validate props indentation in JSX',
+      description: 'Enforce props indentation in JSX',
       category: 'Stylistic Issues',
       recommended: false,
       url: docsUrl('jsx-indent-props'),

--- a/lib/rules/jsx-indent.js
+++ b/lib/rules/jsx-indent.js
@@ -48,7 +48,7 @@ const messages = {
 module.exports = {
   meta: {
     docs: {
-      description: 'Validate JSX indentation',
+      description: 'Enforce JSX indentation',
       category: 'Stylistic Issues',
       recommended: false,
       url: docsUrl('jsx-indent'),

--- a/lib/rules/jsx-key.js
+++ b/lib/rules/jsx-key.js
@@ -34,7 +34,7 @@ const messages = {
 module.exports = {
   meta: {
     docs: {
-      description: 'Report missing `key` props in iterators/collection literals',
+      description: 'Disallow missing `key` props in iterators/collection literals',
       category: 'Possible Errors',
       recommended: true,
       url: docsUrl('jsx-key'),

--- a/lib/rules/jsx-max-depth.js
+++ b/lib/rules/jsx-max-depth.js
@@ -23,7 +23,7 @@ const messages = {
 module.exports = {
   meta: {
     docs: {
-      description: 'Validate JSX maximum depth',
+      description: 'Enforce JSX maximum depth',
       category: 'Stylistic Issues',
       recommended: false,
       url: docsUrl('jsx-max-depth'),

--- a/lib/rules/jsx-max-props-per-line.js
+++ b/lib/rules/jsx-max-props-per-line.js
@@ -26,7 +26,7 @@ const messages = {
 module.exports = {
   meta: {
     docs: {
-      description: 'Limit maximum of props on a single line in JSX',
+      description: 'Enforce maximum of props on a single line in JSX',
       category: 'Stylistic Issues',
       recommended: false,
       url: docsUrl('jsx-max-props-per-line'),

--- a/lib/rules/jsx-no-bind.js
+++ b/lib/rules/jsx-no-bind.js
@@ -26,7 +26,7 @@ const messages = {
 module.exports = {
   meta: {
     docs: {
-      description: 'Prevents usage of Function.prototype.bind and arrow functions in React component props',
+      description: 'Disallow `.bind()` or arrow functions in JSX props',
       category: 'Best Practices',
       recommended: false,
       url: docsUrl('jsx-no-bind'),

--- a/lib/rules/jsx-no-comment-textnodes.js
+++ b/lib/rules/jsx-no-comment-textnodes.js
@@ -36,7 +36,7 @@ function checkText(node, context) {
 module.exports = {
   meta: {
     docs: {
-      description: 'Comments inside children section of tag should be placed inside braces',
+      description: 'Disallow comments from being inserted as text nodes',
       category: 'Possible Errors',
       recommended: true,
       url: docsUrl('jsx-no-comment-textnodes'),
@@ -44,11 +44,7 @@ module.exports = {
 
     messages,
 
-    schema: [{
-      type: 'object',
-      properties: {},
-      additionalProperties: false,
-    }],
+    schema: [],
   },
 
   create(context) {

--- a/lib/rules/jsx-no-constructed-context-values.js
+++ b/lib/rules/jsx-no-constructed-context-values.js
@@ -131,7 +131,7 @@ const messages = {
 module.exports = {
   meta: {
     docs: {
-      description: 'Prevents JSX context provider values from taking values that will cause needless rerenders.',
+      description: 'Disallows JSX context provider values from taking values that will cause needless rerenders',
       category: 'Best Practices',
       recommended: false,
       url: docsUrl('jsx-no-constructed-context-values'),

--- a/lib/rules/jsx-no-duplicate-props.js
+++ b/lib/rules/jsx-no-duplicate-props.js
@@ -20,7 +20,7 @@ const messages = {
 module.exports = {
   meta: {
     docs: {
-      description: 'Enforce no duplicate props',
+      description: 'Disallow duplicate properties in JSX',
       category: 'Possible Errors',
       recommended: true,
       url: docsUrl('jsx-no-duplicate-props'),

--- a/lib/rules/jsx-no-leaked-render.js
+++ b/lib/rules/jsx-no-leaked-render.js
@@ -83,7 +83,7 @@ function ruleFixer(context, fixStrategy, fixer, reportedNode, leftNode, rightNod
 module.exports = {
   meta: {
     docs: {
-      description: 'Prevent problematic leaked values from being rendered',
+      description: 'Disallow problematic leaked values from being rendered',
       category: 'Possible Errors',
       recommended: false,
       url: docsUrl('jsx-no-leaked-render'),

--- a/lib/rules/jsx-no-literals.js
+++ b/lib/rules/jsx-no-literals.js
@@ -27,7 +27,7 @@ const messages = {
 module.exports = {
   meta: {
     docs: {
-      description: 'Prevent using string literals in React component definition',
+      description: 'Disallow usage of string literals in JSX',
       category: 'Stylistic Issues',
       recommended: false,
       url: docsUrl('jsx-no-literals'),

--- a/lib/rules/jsx-no-script-url.js
+++ b/lib/rules/jsx-no-script-url.js
@@ -50,7 +50,7 @@ const messages = {
 module.exports = {
   meta: {
     docs: {
-      description: 'Forbid `javascript:` URLs',
+      description: 'Disallow usage of `javascript:` URLs',
       category: 'Best Practices',
       recommended: false,
       url: docsUrl('jsx-no-script-url'),

--- a/lib/rules/jsx-no-target-blank.js
+++ b/lib/rules/jsx-no-target-blank.js
@@ -113,7 +113,7 @@ module.exports = {
   meta: {
     fixable: 'code',
     docs: {
-      description: 'Forbid `target="_blank"` attribute without `rel="noreferrer"`',
+      description: 'Disallow `target="_blank"` attribute without `rel="noreferrer"`',
       category: 'Best Practices',
       recommended: true,
       url: docsUrl('jsx-no-target-blank'),

--- a/lib/rules/jsx-one-expression-per-line.js
+++ b/lib/rules/jsx-one-expression-per-line.js
@@ -24,7 +24,7 @@ const messages = {
 module.exports = {
   meta: {
     docs: {
-      description: 'Limit to one expression per line in JSX',
+      description: 'Require one JSX element per line',
       category: 'Stylistic Issues',
       recommended: false,
       url: docsUrl('jsx-one-expression-per-line'),

--- a/lib/rules/jsx-props-no-spreading.js
+++ b/lib/rules/jsx-props-no-spreading.js
@@ -41,7 +41,7 @@ const messages = {
 module.exports = {
   meta: {
     docs: {
-      description: 'Prevent JSX prop spreading',
+      description: 'Disallow JSX prop spreading',
       category: 'Best Practices',
       recommended: false,
       url: docsUrl('jsx-props-no-spreading'),

--- a/lib/rules/jsx-sort-default-props.js
+++ b/lib/rules/jsx-sort-default-props.js
@@ -20,7 +20,7 @@ const messages = {
 module.exports = {
   meta: {
     docs: {
-      description: 'Enforce default props alphabetical sorting',
+      description: 'Enforce defaultProps declarations alphabetical sorting',
       category: 'Stylistic Issues',
       recommended: false,
       url: docsUrl('jsx-sort-default-props'),

--- a/lib/rules/jsx-space-before-closing.js
+++ b/lib/rules/jsx-space-before-closing.js
@@ -26,7 +26,7 @@ module.exports = {
   meta: {
     deprecated: true,
     docs: {
-      description: 'Validate spacing before closing bracket in JSX',
+      description: 'Enforce spacing before closing bracket in JSX',
       category: 'Stylistic Issues',
       recommended: false,
       url: docsUrl('jsx-space-before-closing'),

--- a/lib/rules/jsx-tag-spacing.js
+++ b/lib/rules/jsx-tag-spacing.js
@@ -258,7 +258,7 @@ const optionDefaults = {
 module.exports = {
   meta: {
     docs: {
-      description: 'Validate whitespace in and around the JSX opening and closing brackets',
+      description: 'Enforce whitespace in and around the JSX opening and closing brackets',
       category: 'Stylistic Issues',
       recommended: false,
       url: docsUrl('jsx-tag-spacing'),

--- a/lib/rules/jsx-uses-react.js
+++ b/lib/rules/jsx-uses-react.js
@@ -16,7 +16,7 @@ module.exports = {
   // eslint-disable-next-line eslint-plugin/prefer-message-ids -- https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/issues/292
   meta: {
     docs: {
-      description: 'Prevent React to be marked as unused',
+      description: 'Disallow React to be incorrectly marked as unused',
       category: 'Best Practices',
       recommended: true,
       url: docsUrl('jsx-uses-react'),

--- a/lib/rules/jsx-uses-vars.js
+++ b/lib/rules/jsx-uses-vars.js
@@ -18,7 +18,7 @@ module.exports = {
   // eslint-disable-next-line eslint-plugin/prefer-message-ids -- https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/issues/292
   meta: {
     docs: {
-      description: 'Prevent variables used in JSX to be marked as unused',
+      description: 'Disallow variables used in JSX to be incorrectly marked as unused',
       category: 'Best Practices',
       recommended: true,
       url: docsUrl('jsx-uses-vars'),

--- a/lib/rules/jsx-wrap-multilines.js
+++ b/lib/rules/jsx-wrap-multilines.js
@@ -37,7 +37,7 @@ const messages = {
 module.exports = {
   meta: {
     docs: {
-      description: 'Prevent missing parentheses around multilines JSX',
+      description: 'Disallow missing parentheses around multiline JSX',
       category: 'Stylistic Issues',
       recommended: false,
       url: docsUrl('jsx-wrap-multilines'),

--- a/lib/rules/no-access-state-in-setstate.js
+++ b/lib/rules/no-access-state-in-setstate.js
@@ -20,7 +20,7 @@ const messages = {
 module.exports = {
   meta: {
     docs: {
-      description: 'Reports when this.state is accessed within setState',
+      description: 'Disallow when this.state is accessed within setState',
       category: 'Possible Errors',
       recommended: false,
       url: docsUrl('no-access-state-in-setstate'),

--- a/lib/rules/no-adjacent-inline-elements.js
+++ b/lib/rules/no-adjacent-inline-elements.js
@@ -79,7 +79,7 @@ const messages = {
 module.exports = {
   meta: {
     docs: {
-      description: 'Prevent adjacent inline elements not separated by whitespace.',
+      description: 'Disallow adjacent inline elements not separated by whitespace.',
       category: 'Best Practices',
       recommended: false,
       url: docsUrl('no-adjacent-inline-elements'),

--- a/lib/rules/no-array-index-key.js
+++ b/lib/rules/no-array-index-key.js
@@ -44,7 +44,7 @@ const messages = {
 module.exports = {
   meta: {
     docs: {
-      description: 'Prevent usage of Array index in keys',
+      description: 'Disallow usage of Array index in keys',
       category: 'Best Practices',
       recommended: false,
       url: docsUrl('no-array-index-key'),

--- a/lib/rules/no-children-prop.js
+++ b/lib/rules/no-children-prop.js
@@ -40,7 +40,7 @@ const messages = {
 module.exports = {
   meta: {
     docs: {
-      description: 'Prevent passing of children as props.',
+      description: 'Disallow passing of children as props',
       category: 'Best Practices',
       recommended: true,
       url: docsUrl('no-children-prop'),

--- a/lib/rules/no-danger-with-children.js
+++ b/lib/rules/no-danger-with-children.js
@@ -20,7 +20,7 @@ const messages = {
 module.exports = {
   meta: {
     docs: {
-      description: 'Report when a DOM element is using both children and dangerouslySetInnerHTML',
+      description: 'Disallow when a DOM element is using both children and dangerouslySetInnerHTML',
       category: 'Possible Errors',
       recommended: true,
       url: docsUrl('no-danger-with-children'),

--- a/lib/rules/no-danger.js
+++ b/lib/rules/no-danger.js
@@ -46,7 +46,7 @@ const messages = {
 module.exports = {
   meta: {
     docs: {
-      description: 'Prevent usage of dangerous JSX props',
+      description: 'Disallow usage of dangerous JSX properties',
       category: 'Best Practices',
       recommended: false,
       url: docsUrl('no-danger'),

--- a/lib/rules/no-deprecated.js
+++ b/lib/rules/no-deprecated.js
@@ -92,7 +92,7 @@ const messages = {
 module.exports = {
   meta: {
     docs: {
-      description: 'Prevent usage of deprecated methods',
+      description: 'Disallow usage of deprecated methods',
       category: 'Best Practices',
       recommended: true,
       url: docsUrl('no-deprecated'),

--- a/lib/rules/no-direct-mutation-state.js
+++ b/lib/rules/no-direct-mutation-state.js
@@ -22,7 +22,7 @@ const messages = {
 module.exports = {
   meta: {
     docs: {
-      description: 'Prevent direct mutation of this.state',
+      description: 'Disallow direct mutation of this.state',
       category: 'Possible Errors',
       recommended: true,
       url: docsUrl('no-direct-mutation-state'),

--- a/lib/rules/no-find-dom-node.js
+++ b/lib/rules/no-find-dom-node.js
@@ -19,7 +19,7 @@ const messages = {
 module.exports = {
   meta: {
     docs: {
-      description: 'Prevent usage of findDOMNode',
+      description: 'Disallow usage of findDOMNode',
       category: 'Best Practices',
       recommended: true,
       url: docsUrl('no-find-dom-node'),

--- a/lib/rules/no-invalid-html-attribute.js
+++ b/lib/rules/no-invalid-html-attribute.js
@@ -533,7 +533,7 @@ module.exports = {
   meta: {
     fixable: 'code',
     docs: {
-      description: 'Forbid attribute with an invalid values`',
+      description: 'Disallow usage of invalid attributes',
       category: 'Possible Errors',
       url: docsUrl('no-invalid-html-attribute'),
     },

--- a/lib/rules/no-is-mounted.js
+++ b/lib/rules/no-is-mounted.js
@@ -19,7 +19,7 @@ const messages = {
 module.exports = {
   meta: {
     docs: {
-      description: 'Prevent usage of isMounted',
+      description: 'Disallow usage of isMounted',
       category: 'Best Practices',
       recommended: true,
       url: docsUrl('no-is-mounted'),

--- a/lib/rules/no-multi-comp.js
+++ b/lib/rules/no-multi-comp.js
@@ -20,7 +20,7 @@ const messages = {
 module.exports = {
   meta: {
     docs: {
-      description: 'Prevent multiple component definition per file',
+      description: 'Disallow multiple component definition per file',
       category: 'Stylistic Issues',
       recommended: false,
       url: docsUrl('no-multi-comp'),

--- a/lib/rules/no-namespace.js
+++ b/lib/rules/no-namespace.js
@@ -29,10 +29,7 @@ module.exports = {
 
     messages,
 
-    schema: [{
-      type: 'object',
-      additionalProperties: false,
-    }],
+    schema: [],
   },
 
   create(context) {

--- a/lib/rules/no-redundant-should-component-update.js
+++ b/lib/rules/no-redundant-should-component-update.js
@@ -20,7 +20,7 @@ const messages = {
 module.exports = {
   meta: {
     docs: {
-      description: 'Flag shouldComponentUpdate when extending PureComponent',
+      description: 'Disallow usage of shouldComponentUpdate when extending React.PureComponent',
       category: 'Possible Errors',
       recommended: false,
       url: docsUrl('no-redundant-should-component-update'),

--- a/lib/rules/no-render-return-value.js
+++ b/lib/rules/no-render-return-value.js
@@ -20,7 +20,7 @@ const messages = {
 module.exports = {
   meta: {
     docs: {
-      description: 'Prevent usage of the return value of React.render',
+      description: 'Disallow usage of the return value of ReactDOM.render',
       category: 'Best Practices',
       recommended: true,
       url: docsUrl('no-render-return-value'),

--- a/lib/rules/no-set-state.js
+++ b/lib/rules/no-set-state.js
@@ -20,7 +20,7 @@ const messages = {
 module.exports = {
   meta: {
     docs: {
-      description: 'Prevent usage of setState',
+      description: 'Disallow usage of setState',
       category: 'Stylistic Issues',
       recommended: false,
       url: docsUrl('no-set-state'),

--- a/lib/rules/no-string-refs.js
+++ b/lib/rules/no-string-refs.js
@@ -21,7 +21,7 @@ const messages = {
 module.exports = {
   meta: {
     docs: {
-      description: 'Prevent string definitions for references and prevent referencing this.refs',
+      description: 'Disallow using string references',
       category: 'Best Practices',
       recommended: true,
       url: docsUrl('no-string-refs'),

--- a/lib/rules/no-this-in-sfc.js
+++ b/lib/rules/no-this-in-sfc.js
@@ -19,7 +19,7 @@ const messages = {
 module.exports = {
   meta: {
     docs: {
-      description: 'Report "this" being used in stateless components',
+      description: 'Disallow `this` from being used in stateless functional components',
       category: 'Possible Errors',
       recommended: false,
       url: docsUrl('no-this-in-sfc'),

--- a/lib/rules/no-typos.js
+++ b/lib/rules/no-typos.js
@@ -31,7 +31,7 @@ const messages = {
 module.exports = {
   meta: {
     docs: {
-      description: 'Prevent common typos',
+      description: 'Disallow common typos',
       category: 'Stylistic Issues',
       recommended: false,
       url: docsUrl('no-typos'),

--- a/lib/rules/no-unescaped-entities.js
+++ b/lib/rules/no-unescaped-entities.js
@@ -38,7 +38,7 @@ const messages = {
 module.exports = {
   meta: {
     docs: {
-      description: 'Detect unescaped HTML entities, which might represent malformed tags',
+      description: 'Disallow unescaped HTML entities from appearing in markup',
       category: 'Possible Errors',
       recommended: true,
       url: docsUrl('no-unescaped-entities'),

--- a/lib/rules/no-unknown-property.js
+++ b/lib/rules/no-unknown-property.js
@@ -221,7 +221,7 @@ const messages = {
 module.exports = {
   meta: {
     docs: {
-      description: 'Prevent usage of unknown DOM property',
+      description: 'Disallow usage of unknown DOM property',
       category: 'Possible Errors',
       recommended: true,
       url: docsUrl('no-unknown-property'),

--- a/lib/rules/no-unsafe.js
+++ b/lib/rules/no-unsafe.js
@@ -22,7 +22,7 @@ const messages = {
 module.exports = {
   meta: {
     docs: {
-      description: 'Prevent usage of unsafe lifecycle methods',
+      description: 'Disallow usage of unsafe lifecycle methods',
       category: 'Best Practices',
       recommended: false,
       url: docsUrl('no-unsafe'),

--- a/lib/rules/no-unstable-nested-components.js
+++ b/lib/rules/no-unstable-nested-components.js
@@ -268,7 +268,7 @@ function resolveComponentName(node) {
 module.exports = {
   meta: {
     docs: {
-      description: 'Prevent creating unstable components inside components',
+      description: 'Disallow creating unstable components inside components',
       category: 'Possible Errors',
       recommended: false,
       url: docsUrl('no-unstable-nested-components'),

--- a/lib/rules/no-unused-class-component-methods.js
+++ b/lib/rules/no-unused-class-component-methods.js
@@ -101,18 +101,13 @@ const messages = {
 module.exports = {
   meta: {
     docs: {
-      description: 'Prevent declaring unused methods of component class',
+      description: 'Disallow declaring unused methods of component class',
       category: 'Best Practices',
       recommended: false,
       url: docsUrl('no-unused-class-component-methods'),
     },
     messages,
-    schema: [
-      {
-        type: 'object',
-        additionalProperties: false,
-      },
-    ],
+    schema: [],
   },
 
   create: ((context) => {

--- a/lib/rules/no-unused-prop-types.js
+++ b/lib/rules/no-unused-prop-types.js
@@ -23,7 +23,7 @@ const messages = {
 module.exports = {
   meta: {
     docs: {
-      description: 'Prevent definitions of unused prop types',
+      description: 'Disallow definitions of unused propTypes',
       category: 'Best Practices',
       recommended: false,
       url: docsUrl('no-unused-prop-types'),

--- a/lib/rules/no-unused-state.js
+++ b/lib/rules/no-unused-state.js
@@ -80,7 +80,7 @@ const messages = {
 module.exports = {
   meta: {
     docs: {
-      description: 'Prevent definition of unused state fields',
+      description: 'Disallow definitions of unused state',
       category: 'Best Practices',
       recommended: false,
       url: docsUrl('no-unused-state'),

--- a/lib/rules/prefer-read-only-props.js
+++ b/lib/rules/prefer-read-only-props.js
@@ -35,7 +35,7 @@ const messages = {
 module.exports = {
   meta: {
     docs: {
-      description: 'Require read-only props.',
+      description: 'Enforce that props are read-only',
       category: 'Stylistic Issues',
       recommended: false,
       url: docsUrl('prefer-read-only-props'),

--- a/lib/rules/prop-types.js
+++ b/lib/rules/prop-types.js
@@ -23,7 +23,7 @@ const messages = {
 module.exports = {
   meta: {
     docs: {
-      description: 'Prevent missing props validation in a React component definition',
+      description: 'Disallow missing props validation in a React component definition',
       category: 'Best Practices',
       recommended: true,
       url: docsUrl('prop-types'),

--- a/lib/rules/react-in-jsx-scope.js
+++ b/lib/rules/react-in-jsx-scope.js
@@ -21,7 +21,7 @@ const messages = {
 module.exports = {
   meta: {
     docs: {
-      description: 'Prevent missing React when using JSX',
+      description: 'Disallow missing React when using JSX',
       category: 'Possible Errors',
       recommended: true,
       url: docsUrl('react-in-jsx-scope'),

--- a/lib/rules/require-default-props.js
+++ b/lib/rules/require-default-props.js
@@ -27,7 +27,7 @@ const messages = {
 module.exports = {
   meta: {
     docs: {
-      description: 'Enforce a defaultProps definition for every prop that is not a required prop.',
+      description: 'Enforce a defaultProps definition for every prop that is not a required prop',
       category: 'Best Practices',
       url: docsUrl('require-default-props'),
     },

--- a/lib/rules/self-closing-comp.js
+++ b/lib/rules/self-closing-comp.js
@@ -22,7 +22,7 @@ const messages = {
 module.exports = {
   meta: {
     docs: {
-      description: 'Prevent extra closing tags for components without children',
+      description: 'Disallow extra closing tags for components without children',
       category: 'Stylistic Issues',
       recommended: false,
       url: docsUrl('self-closing-comp'),

--- a/lib/rules/state-in-constructor.js
+++ b/lib/rules/state-in-constructor.js
@@ -22,7 +22,7 @@ const messages = {
 module.exports = {
   meta: {
     docs: {
-      description: 'State initialization in an ES6 class component should be in a constructor',
+      description: 'Enforce class component state initialization style',
       category: 'Stylistic Issues',
       recommended: false,
       url: docsUrl('state-in-constructor'),

--- a/lib/rules/static-property-placement.js
+++ b/lib/rules/static-property-placement.js
@@ -58,7 +58,7 @@ const messages = {
 module.exports = {
   meta: {
     docs: {
-      description: 'Defines where React component static properties should be positioned.',
+      description: 'Enforces where React component static properties should be positioned.',
       category: 'Stylistic Issues',
       recommended: false,
       url: docsUrl('static-property-placement'),

--- a/lib/rules/void-dom-elements-no-children.js
+++ b/lib/rules/void-dom-elements-no-children.js
@@ -50,7 +50,7 @@ const noChildrenInVoidEl = 'Void DOM element <{{element}} /> cannot receive chil
 module.exports = {
   meta: {
     docs: {
-      description: 'Prevent passing of children to void DOM elements (e.g. `<br />`).',
+      description: 'Disallow void DOM elements (e.g. `<img />`, `<br />`) from receiving children',
       category: 'Best Practices',
       recommended: false,
       url: docsUrl('void-dom-elements-no-children'),

--- a/lib/util/makeNoMethodSetStateRule.js
+++ b/lib/util/makeNoMethodSetStateRule.js
@@ -45,7 +45,7 @@ module.exports = function makeNoMethodSetStateRule(methodName, shouldCheckUnsafe
   return {
     meta: {
       docs: {
-        description: `Prevent usage of setState in ${methodName}`,
+        description: `Disallow usage of setState in ${methodName}`,
         category: 'Best Practices',
         recommended: false,
         url: docsUrl(mapTitle(methodName)),

--- a/tests/index.js
+++ b/tests/index.js
@@ -29,36 +29,57 @@ describe('rule documentation files have the correct content', () => {
   };
 
   ruleFiles.forEach((ruleName) => {
-    const rule = plugin.rules[ruleName];
-    const documentPath = path.join('docs', 'rules', `${ruleName}.md`);
-    const documentContents = fs.readFileSync(documentPath, 'utf8');
-    const documentLines = documentContents.split('\n');
+    it(ruleName, () => {
+      const rule = plugin.rules[ruleName];
+      const documentPath = path.join('docs', 'rules', `${ruleName}.md`);
+      const documentContents = fs.readFileSync(documentPath, 'utf8');
+      const documentLines = documentContents.split('\n');
 
-    // Decide which notices should be shown at the top of the doc.
-    const expectedNotices = [];
-    const unexpectedNotices = [];
-    if (rule.meta.fixable) {
-      expectedNotices.push('fixable');
-    } else {
-      unexpectedNotices.push('fixable');
-    }
-    if (rule.meta.hasSuggestions) {
-      expectedNotices.push('hasSuggestions');
-    } else {
-      unexpectedNotices.push('hasSuggestions');
-    }
+      // Check title.
+      const expectedTitle = `# ${rule.meta.docs.description} (react/${ruleName})`;
+      assert.strictEqual(documentLines[0], expectedTitle, 'includes the rule description and name in title');
 
-    // Ensure that expected notices are present in the correct order.
-    let currentLineNumber = 1;
-    expectedNotices.forEach((expectedNotice) => {
-      assert.strictEqual(documentLines[currentLineNumber], '', `${ruleName} includes blank line ahead of ${expectedNotice} notice`);
-      assert.strictEqual(documentLines[currentLineNumber + 1], MESSAGES[expectedNotice], `${ruleName} includes ${expectedNotice} notice`);
-      currentLineNumber += 2;
-    });
+      // Decide which notices should be shown at the top of the doc.
+      const expectedNotices = [];
+      const unexpectedNotices = [];
+      if (rule.meta.fixable) {
+        expectedNotices.push('fixable');
+      } else {
+        unexpectedNotices.push('fixable');
+      }
+      if (rule.meta.hasSuggestions) {
+        expectedNotices.push('hasSuggestions');
+      } else {
+        unexpectedNotices.push('hasSuggestions');
+      }
 
-    // Ensure that unexpected notices are not present.
-    unexpectedNotices.forEach((unexpectedNotice) => {
-      assert.ok(!documentContents.includes(MESSAGES[unexpectedNotice]), `${ruleName} does not include unexpected ${unexpectedNotice} notice`);
+      // Ensure that expected notices are present in the correct order.
+      let currentLineNumber = 1;
+      expectedNotices.forEach((expectedNotice) => {
+        assert.strictEqual(documentLines[currentLineNumber], '', `includes blank line ahead of ${expectedNotice} notice`);
+        assert.strictEqual(documentLines[currentLineNumber + 1], MESSAGES[expectedNotice], `includes ${expectedNotice} notice`);
+        currentLineNumber += 2;
+      });
+
+      // Ensure that unexpected notices are not present.
+      unexpectedNotices.forEach((unexpectedNotice) => {
+        assert.ok(!documentContents.includes(MESSAGES[unexpectedNotice]), `does not include unexpected ${unexpectedNotice} notice`);
+      });
+
+      // Check for Rule Details section.
+      assert.ok(documentContents.includes('## Rule Details'), 'should have a "## Rule Details" section');
+
+      // Check if the rule has configuration options.
+      if (
+        (Array.isArray(rule.meta.schema) && rule.meta.schema.length > 0)
+        || (typeof rule.meta.schema === 'object' && Object.keys(rule.meta.schema).length > 0)
+      ) {
+        // Should have an options section header:
+        assert.ok(documentContents.includes('## Rule Options'), 'should have a "## Rule Options" section');
+      } else {
+        // Should NOT have any options section header:
+        assert.ok(!documentContents.includes('## Rule Options'), 'should not have a "## Rule Options" section');
+      }
     });
   });
 });


### PR DESCRIPTION
This is a follow-up to https://github.com/jsx-eslint/eslint-plugin-react/pull/3359 to further improve rule doc consistency.

Changes included:

1. Many rule descriptions were out-of-sync between their rule doc title and `meta.docs.description` property. I updated these to be consistent.
2. Updated all rule descriptions to begin with "Enforce", "Require", or "Disallow" which follows ESLint [conventions](https://eslint.org/docs/latest/rules/) and is now enforced by [eslint-plugin/require-meta-docs-description](https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/blob/main/docs/rules/require-meta-docs-description.md).
3. Added tests that all rule docs have the correct title, a "Rule Details" section, and a "Rule Options" section only if they have options.
   * This also uncovered a few rules which incorrectly specified a schema when they actually had no options. Closes #2340 Closes #2341.
