### PR TITLE
Add config notice to rule docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,11 +41,13 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 * [Docs] Standardize deprecated rule notice ([#3364][] @bmish)
 * [Docs] Fix typos ([#3366][] @bmish)
 * [Docs] Add markdownlint for documentation formatting consistency ([#3367][] @bmish)
+* [Docs] Add config notice to rule docs ([#3362][] @bmish)
 
 [#3367]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3367
 [#3366]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3366
 [#3365]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3365
 [#3364]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3364
+[#3362]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3362
 [#3361]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3361
 [#3359]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3359
 [#3355]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3355

--- a/docs/rules/boolean-prop-naming.md
+++ b/docs/rules/boolean-prop-naming.md
@@ -1,5 +1,7 @@
 # Enforces consistent naming for boolean props (react/boolean-prop-naming)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 Allows you to enforce a consistent naming pattern for props which expect a boolean value.
 
 > **Note**: You can provide types in runtime types using [PropTypes] and/or

--- a/docs/rules/button-has-type.md
+++ b/docs/rules/button-has-type.md
@@ -1,5 +1,7 @@
 # Disallow usage of `button` elements without an explicit `type` attribute (react/button-has-type)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 The default value of `type` attribute for `button` HTML element is `"submit"` which is often not the desired behavior and may lead to unexpected page reloads.
 This rules enforces an explicit `type` attribute for all the `button` elements and checks that its value is valid per spec (i.e., is one of `"button"`, `"submit"`, and `"reset"`).
 

--- a/docs/rules/default-props-match-prop-types.md
+++ b/docs/rules/default-props-match-prop-types.md
@@ -1,5 +1,7 @@
 # Enforce all defaultProps have a corresponding non-required PropType (react/default-props-match-prop-types)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 This rule aims to ensure that any prop in `defaultProps` has a non-required type
 definition.
 

--- a/docs/rules/destructuring-assignment.md
+++ b/docs/rules/destructuring-assignment.md
@@ -1,5 +1,7 @@
 # Enforce consistent usage of destructuring assignment of props, state, and context (react/destructuring-assignment)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 🔧 This rule is automatically fixable using the `--fix` [flag](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) on the command line.
 
 Rule can be set to either of `always` or `never`;

--- a/docs/rules/display-name.md
+++ b/docs/rules/display-name.md
@@ -1,5 +1,7 @@
 # Disallow missing displayName in a React component definition (react/display-name)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`, `recommended`.
+
 DisplayName allows you to name your component. This name is used by React in debugging messages.
 
 ## Rule Details

--- a/docs/rules/forbid-component-props.md
+++ b/docs/rules/forbid-component-props.md
@@ -1,5 +1,7 @@
 # Disallow certain props on components (react/forbid-component-props)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 By default this rule prevents passing of [props that add lots of complexity](https://medium.com/brigade-engineering/don-t-pass-css-classes-between-components-e9f7ab192785) (`className`, `style`) to Components. This rule only applies to Components (e.g. `<Foo />`) and not DOM nodes (e.g. `<div />`). The list of forbidden props can be customized with the `forbid` option.
 
 ## Rule Details

--- a/docs/rules/forbid-dom-props.md
+++ b/docs/rules/forbid-dom-props.md
@@ -1,5 +1,7 @@
 # Disallow certain props on DOM Nodes (react/forbid-dom-props)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 This rule prevents passing of props to elements. This rule only applies to DOM Nodes (e.g. `<div />`) and not Components (e.g. `<Component />`).
 The list of forbidden props can be customized with the `forbid` option.
 

--- a/docs/rules/forbid-elements.md
+++ b/docs/rules/forbid-elements.md
@@ -1,5 +1,7 @@
 # Disallow certain elements (react/forbid-elements)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 You may want to forbid usage of certain elements in favor of others, (e.g. forbid all `<div />` and use `<Box />` instead). This rule allows you to configure a list of forbidden elements and to specify their desired replacements.
 
 ## Rule Details

--- a/docs/rules/forbid-foreign-prop-types.md
+++ b/docs/rules/forbid-foreign-prop-types.md
@@ -1,5 +1,7 @@
 # Disallow using another component's propTypes (react/forbid-foreign-prop-types)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 This rule forbids using another component's prop types unless they are explicitly imported/exported. This allows people who want to use [babel-plugin-transform-react-remove-prop-types](https://github.com/oliviertassinari/babel-plugin-transform-react-remove-prop-types) to remove propTypes from their components in production builds, to do so safely.
 
 In order to ensure that imports are explicitly exported it is recommended to use the ["named" rule in eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import/blob/HEAD/docs/rules/named.md) in conjunction with this rule.

--- a/docs/rules/forbid-prop-types.md
+++ b/docs/rules/forbid-prop-types.md
@@ -1,5 +1,7 @@
 # Disallow certain propTypes (react/forbid-prop-types)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 By default this rule prevents vague prop types with more specific alternatives available (`any`, `array`, `object`), but any prop type can be disabled if desired. The defaults are chosen because they have obvious replacements. `any` should be replaced with, well, anything. `array` and `object` can be replaced with `arrayOf` and `shape`, respectively.
 
 ## Rule Details

--- a/docs/rules/function-component-definition.md
+++ b/docs/rules/function-component-definition.md
@@ -1,5 +1,7 @@
 # Enforce a specific function type for function components (react/function-component-definition)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 🔧 This rule is automatically fixable using the `--fix` [flag](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) on the command line.
 
 This option enforces a specific function type for function components.

--- a/docs/rules/hook-use-state.md
+++ b/docs/rules/hook-use-state.md
@@ -1,5 +1,7 @@
 # Ensure destructuring and symmetric naming of useState hook value and setter variables (react/hook-use-state)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 💡 This rule provides editor [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
 
 ## Rule Details

--- a/docs/rules/iframe-missing-sandbox.md
+++ b/docs/rules/iframe-missing-sandbox.md
@@ -1,5 +1,7 @@
 # Enforce sandbox attribute on iframe elements (react/iframe-missing-sandbox)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 The sandbox attribute enables an extra set of restrictions for the content in the iframe. Using sandbox attribute is considered a good security practice.
 
 See <https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-sandbox>

--- a/docs/rules/jsx-boolean-value.md
+++ b/docs/rules/jsx-boolean-value.md
@@ -1,5 +1,7 @@
 # Enforce boolean attributes notation in JSX (react/jsx-boolean-value)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 🔧 This rule is automatically fixable using the `--fix` [flag](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) on the command line.
 
 [When using a boolean attribute in JSX](https://facebook.github.io/react/docs/jsx-in-depth.html#boolean-attributes), you can set the attribute value to `true` or omit the value.

--- a/docs/rules/jsx-child-element-spacing.md
+++ b/docs/rules/jsx-child-element-spacing.md
@@ -1,5 +1,7 @@
 # Enforce or disallow spaces inside of curly braces in JSX attributes and expressions (react/jsx-child-element-spacing)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 ## Rule Details
 
 Since React removes extraneous new lines between elements when possible, it is possible to end up with inline elements that are not rendered with spaces between them and adjacent text. This is often indicative of an error, so this rule attempts to detect JSX markup with ambiguous spacing.

--- a/docs/rules/jsx-closing-bracket-location.md
+++ b/docs/rules/jsx-closing-bracket-location.md
@@ -1,5 +1,7 @@
 # Enforce closing bracket location in JSX (react/jsx-closing-bracket-location)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 🔧 This rule is automatically fixable using the `--fix` [flag](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) on the command line.
 
 Enforce the closing bracket location for JSX multiline elements.

--- a/docs/rules/jsx-closing-tag-location.md
+++ b/docs/rules/jsx-closing-tag-location.md
@@ -1,5 +1,7 @@
 # Enforce closing tag location for multiline JSX (react/jsx-closing-tag-location)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 🔧 This rule is automatically fixable using the `--fix` [flag](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) on the command line.
 
 Enforce the closing tag location for multiline JSX elements.

--- a/docs/rules/jsx-curly-brace-presence.md
+++ b/docs/rules/jsx-curly-brace-presence.md
@@ -1,5 +1,7 @@
 # Disallow unnecessary JSX expressions when literals alone are sufficient or enforce JSX expressions on literals in JSX children or attributes (react/jsx-curly-brace-presence)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 🔧 This rule is automatically fixable using the `--fix` [flag](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) on the command line.
 
 This rule allows you to enforce curly braces or disallow unnecessary curly braces in JSX props and/or children.

--- a/docs/rules/jsx-curly-newline.md
+++ b/docs/rules/jsx-curly-newline.md
@@ -1,5 +1,7 @@
 # Enforce consistent linebreaks in curly braces in JSX attributes and expressions (react/jsx-curly-newline)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 🔧 This rule is automatically fixable using the `--fix` [flag](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) on the command line.
 
 Many style guides require or disallow newlines inside of jsx curly expressions.

--- a/docs/rules/jsx-curly-spacing.md
+++ b/docs/rules/jsx-curly-spacing.md
@@ -1,5 +1,7 @@
 # Enforce or disallow spaces inside of curly braces in JSX attributes and expressions (react/jsx-curly-spacing)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 🔧 This rule is automatically fixable using the `--fix` [flag](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) on the command line.
 
 While formatting preferences are very personal, a number of style guides require or disallow spaces between curly braces.

--- a/docs/rules/jsx-equals-spacing.md
+++ b/docs/rules/jsx-equals-spacing.md
@@ -1,5 +1,7 @@
 # Enforce or disallow spaces around equal signs in JSX attributes (react/jsx-equals-spacing)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 🔧 This rule is automatically fixable using the `--fix` [flag](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) on the command line.
 
 Some style guides require or disallow spaces around equal signs.

--- a/docs/rules/jsx-filename-extension.md
+++ b/docs/rules/jsx-filename-extension.md
@@ -1,5 +1,7 @@
 # Disallow file extensions that may contain JSX (react/jsx-filename-extension)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 ## Rule Details
 
 Examples of **incorrect** code for this rule:

--- a/docs/rules/jsx-first-prop-new-line.md
+++ b/docs/rules/jsx-first-prop-new-line.md
@@ -1,5 +1,7 @@
 # Enforce proper position of the first property in JSX (react/jsx-first-prop-new-line)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 🔧 This rule is automatically fixable using the `--fix` [flag](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) on the command line.
 
 Ensure correct position of the first property.

--- a/docs/rules/jsx-fragments.md
+++ b/docs/rules/jsx-fragments.md
@@ -1,5 +1,7 @@
 # Enforce shorthand or standard form for React fragments (react/jsx-fragments)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 🔧 This rule is automatically fixable using the `--fix` [flag](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) on the command line.
 
 In JSX, a React [fragment] is created either with `<React.Fragment>...</React.Fragment>`, or, using the shorthand syntax, `<>...</>`.

--- a/docs/rules/jsx-handler-names.md
+++ b/docs/rules/jsx-handler-names.md
@@ -1,5 +1,7 @@
 # Enforce event handler naming conventions in JSX (react/jsx-handler-names)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 Ensures that any component or prop methods used to handle events are correctly prefixed.
 
 ## Rule Details

--- a/docs/rules/jsx-indent-props.md
+++ b/docs/rules/jsx-indent-props.md
@@ -1,5 +1,7 @@
 # Enforce props indentation in JSX (react/jsx-indent-props)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 🔧 This rule is automatically fixable using the `--fix` [flag](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) on the command line.
 
 This option validates a specific indentation style for props.

--- a/docs/rules/jsx-indent.md
+++ b/docs/rules/jsx-indent.md
@@ -1,5 +1,7 @@
 # Enforce JSX indentation (react/jsx-indent)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 🔧 This rule is automatically fixable using the `--fix` [flag](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) on the command line.
 
 This option validates a specific indentation style for JSX.

--- a/docs/rules/jsx-key.md
+++ b/docs/rules/jsx-key.md
@@ -1,5 +1,7 @@
 # Disallow missing `key` props in iterators/collection literals (react/jsx-key)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`, `recommended`.
+
 Warn if an element that likely requires a `key` prop--namely, one present in an
 array literal or an arrow function expression.
 

--- a/docs/rules/jsx-max-depth.md
+++ b/docs/rules/jsx-max-depth.md
@@ -1,5 +1,7 @@
 # Enforce JSX maximum depth (react/jsx-max-depth)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 This option validates a specific depth for JSX.
 
 ## Rule Details

--- a/docs/rules/jsx-max-props-per-line.md
+++ b/docs/rules/jsx-max-props-per-line.md
@@ -1,5 +1,7 @@
 # Enforce maximum of props on a single line in JSX (react/jsx-max-props-per-line)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 🔧 This rule is automatically fixable using the `--fix` [flag](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) on the command line.
 
 Limiting the maximum of props on a single line can improve readability.

--- a/docs/rules/jsx-newline.md
+++ b/docs/rules/jsx-newline.md
@@ -1,5 +1,7 @@
 # Require or prevent a new line after jsx elements and expressions. (react/jsx-newline)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 🔧 This rule is automatically fixable using the `--fix` [flag](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) on the command line.
 
 ## Rule Details

--- a/docs/rules/jsx-no-bind.md
+++ b/docs/rules/jsx-no-bind.md
@@ -1,5 +1,7 @@
 # Disallow `.bind()` or arrow functions in JSX props (react/jsx-no-bind)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 A `bind` call or [arrow function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions) in a JSX prop will create a brand new function on every single render. This is bad for performance, as it may cause unnecessary re-renders if a brand new function is passed as a prop to a component that uses reference equality check on the prop to determine if it should update.
 
 Note that this behavior is different for `ref` props, which is a special case in React that **does not** cause re-renders when a brand new function is passed.  See [`ignore-refs`](#ignorerefs) below for more information.

--- a/docs/rules/jsx-no-comment-textnodes.md
+++ b/docs/rules/jsx-no-comment-textnodes.md
@@ -1,5 +1,7 @@
 # Disallow comments from being inserted as text nodes (react/jsx-no-comment-textnodes)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`, `recommended`.
+
 This rule prevents comment strings (e.g. beginning with `//` or `/*`) from being accidentally
 injected as a text node in JSX statements.
 

--- a/docs/rules/jsx-no-constructed-context-values.md
+++ b/docs/rules/jsx-no-constructed-context-values.md
@@ -1,5 +1,7 @@
 # Disallows JSX context provider values from taking values that will cause needless rerenders (react/jsx-no-constructed-context-values)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 This rule prevents non-stable values (i.e. object identities) from being used as a value for `Context.Provider`.
 
 ## Rule Details

--- a/docs/rules/jsx-no-duplicate-props.md
+++ b/docs/rules/jsx-no-duplicate-props.md
@@ -1,5 +1,7 @@
 # Disallow duplicate properties in JSX (react/jsx-no-duplicate-props)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`, `recommended`.
+
 Creating JSX elements with duplicate props can cause unexpected behavior in your application.
 
 ## Rule Details

--- a/docs/rules/jsx-no-leaked-render.md
+++ b/docs/rules/jsx-no-leaked-render.md
@@ -1,5 +1,7 @@
 # Disallow problematic leaked values from being rendered (react/jsx-no-leaked-render)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 🔧 This rule is automatically fixable using the `--fix` [flag](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) on the command line.
 
 Using the `&&` operator to render some element conditionally in JSX can cause unexpected values being rendered, or even crashing the rendering.

--- a/docs/rules/jsx-no-literals.md
+++ b/docs/rules/jsx-no-literals.md
@@ -1,5 +1,7 @@
 # Disallow usage of string literals in JSX (react/jsx-no-literals)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 There are a few scenarios where you want to avoid string literals in JSX. You may want to enforce consistency, reduce syntax highlighting issues, or ensure that strings are part of a translation system.
 
 ## Rule Details

--- a/docs/rules/jsx-no-script-url.md
+++ b/docs/rules/jsx-no-script-url.md
@@ -1,5 +1,7 @@
 # Disallow usage of `javascript:` URLs (react/jsx-no-script-url)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 **In React 16.9** any URLs starting with `javascript:` [scheme](https://wiki.whatwg.org/wiki/URL_schemes#javascript:_URLs) log a warning.
 React considers the pattern as a dangerous attack surface, see [details](https://reactjs.org/blog/2019/08/08/react-v16.9.0.html#deprecating-javascript-urls).
 **In a future major release**, React will throw an error if it encounters a `javascript:` URL.

--- a/docs/rules/jsx-no-target-blank.md
+++ b/docs/rules/jsx-no-target-blank.md
@@ -1,5 +1,7 @@
 # Disallow `target="_blank"` attribute without `rel="noreferrer"` (react/jsx-no-target-blank)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`, `recommended`.
+
 🔧 This rule is automatically fixable using the `--fix` [flag](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) on the command line.
 
 When creating a JSX element that has an `a` tag, it is often desired to have the link open in a new tab using the `target='_blank'` attribute. Using this attribute unaccompanied by `rel='noreferrer'`, however, is a severe security vulnerability (see [noreferrer docs](https://html.spec.whatwg.org/multipage/links.html#link-type-noreferrer) and [noopener docs](https://html.spec.whatwg.org/multipage/links.html#link-type-noopener) for more details)

--- a/docs/rules/jsx-no-undef.md
+++ b/docs/rules/jsx-no-undef.md
@@ -1,5 +1,7 @@
 # Disallow undeclared variables in JSX (react/jsx-no-undef)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`, `recommended`.
+
 This rule helps locate potential ReferenceErrors resulting from misspellings or missing components.
 
 ## Rule Details

--- a/docs/rules/jsx-no-useless-fragment.md
+++ b/docs/rules/jsx-no-useless-fragment.md
@@ -1,5 +1,7 @@
 # Disallow unnecessary fragments (react/jsx-no-useless-fragment)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 🔧 This rule is automatically fixable using the `--fix` [flag](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) on the command line.
 
 A fragment is redundant if it contains only one child, or if it is the child of a html element, and is not a [keyed fragment](https://reactjs.org/docs/fragments.html#keyed-fragments).

--- a/docs/rules/jsx-one-expression-per-line.md
+++ b/docs/rules/jsx-one-expression-per-line.md
@@ -1,5 +1,7 @@
 # Require one JSX element per line (react/jsx-one-expression-per-line)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 🔧 This rule is automatically fixable using the `--fix` [flag](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) on the command line.
 
 This option limits every line in JSX to one expression each.

--- a/docs/rules/jsx-pascal-case.md
+++ b/docs/rules/jsx-pascal-case.md
@@ -1,5 +1,7 @@
 # Enforce PascalCase for user-defined JSX components (react/jsx-pascal-case)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 Enforces coding style that user-defined JSX components are defined and referenced in PascalCase.
 
 Note that since React's JSX uses the upper vs. lower case convention to distinguish between local component classes and HTML tags this rule will not warn on components that start with a lower case letter.

--- a/docs/rules/jsx-props-no-multi-spaces.md
+++ b/docs/rules/jsx-props-no-multi-spaces.md
@@ -1,5 +1,7 @@
 # Disallow multiple spaces between inline JSX props (react/jsx-props-no-multi-spaces)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 🔧 This rule is automatically fixable using the `--fix` [flag](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) on the command line.
 
 Enforces that there is exactly one space between all attributes and after tag name and the first attribute in the same line.

--- a/docs/rules/jsx-props-no-spreading.md
+++ b/docs/rules/jsx-props-no-spreading.md
@@ -1,5 +1,7 @@
 # Disallow JSX prop spreading (react/jsx-props-no-spreading)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 Enforces that there is no spreading for any JSX attribute. This enhances readability of code by being more explicit about what props are received by the component. It is also good for maintainability by avoiding passing unintentional extra props and allowing react to emit warnings when invalid HTML props are passed to HTML elements.
 
 ## Rule Details

--- a/docs/rules/jsx-sort-default-props.md
+++ b/docs/rules/jsx-sort-default-props.md
@@ -1,5 +1,7 @@
 # Enforce defaultProps declarations alphabetical sorting (react/jsx-sort-default-props)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 Some developers prefer to sort `defaultProps` declarations alphabetically to be able to find necessary declarations easier at a later time. Others feel that it adds complexity and becomes a burden to maintain.
 
 ## Rule Details

--- a/docs/rules/jsx-sort-props.md
+++ b/docs/rules/jsx-sort-props.md
@@ -1,5 +1,7 @@
 # Enforce props alphabetical sorting (react/jsx-sort-props)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 🔧 This rule is automatically fixable using the `--fix` [flag](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) on the command line.
 
 Some developers prefer to sort props names alphabetically to be able to find necessary props easier at the later time. Others feel that it adds complexity and becomes burden to maintain.

--- a/docs/rules/jsx-tag-spacing.md
+++ b/docs/rules/jsx-tag-spacing.md
@@ -1,5 +1,7 @@
 # Enforce whitespace in and around the JSX opening and closing brackets (react/jsx-tag-spacing)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 🔧 This rule is automatically fixable using the `--fix` [flag](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) on the command line.
 
 Enforce or forbid spaces after the opening bracket, before the closing bracket, before the closing bracket of self-closing elements, and between the angle bracket and slash of JSX closing or self-closing elements.

--- a/docs/rules/jsx-uses-react.md
+++ b/docs/rules/jsx-uses-react.md
@@ -1,5 +1,7 @@
 # Disallow React to be incorrectly marked as unused (react/jsx-uses-react)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`, `recommended`. This rule is disabled in the following configs: `jsx-runtime`.
+
 JSX expands to a call to `React.createElement`, a file which includes `React`
 but only uses JSX should consider the `React` variable as used.
 

--- a/docs/rules/jsx-uses-vars.md
+++ b/docs/rules/jsx-uses-vars.md
@@ -1,5 +1,7 @@
 # Disallow variables used in JSX to be incorrectly marked as unused (react/jsx-uses-vars)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`, `recommended`.
+
 Since 0.17.0 the `eslint` `no-unused-vars` rule does not detect variables used in JSX ([see details](https://eslint.org/blog/2015/03/eslint-0.17.0-released#changes-to-jsxreact-handling)). This rule will find variables used in JSX and mark them as used.
 
 This rule only has an effect when the `no-unused-vars` rule is enabled.

--- a/docs/rules/jsx-wrap-multilines.md
+++ b/docs/rules/jsx-wrap-multilines.md
@@ -1,5 +1,7 @@
 # Disallow missing parentheses around multiline JSX (react/jsx-wrap-multilines)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 🔧 This rule is automatically fixable using the `--fix` [flag](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) on the command line.
 
 Wrapping multiline JSX in parentheses can improve readability and/or convenience.

--- a/docs/rules/no-access-state-in-setstate.md
+++ b/docs/rules/no-access-state-in-setstate.md
@@ -1,5 +1,7 @@
 # Disallow when this.state is accessed within setState (react/no-access-state-in-setstate)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 Usage of `this.state` inside `setState` calls might result in errors when two state calls are called in batch and thus referencing old state and not the current state.
 
 ## Rule Details

--- a/docs/rules/no-adjacent-inline-elements.md
+++ b/docs/rules/no-adjacent-inline-elements.md
@@ -1,5 +1,7 @@
 # Disallow adjacent inline elements not separated by whitespace. (react/no-adjacent-inline-elements)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 Adjacent inline elements not separated by whitespace will bump up against each
 other when viewed in an unstyled manner, which usually isn't desirable.
 

--- a/docs/rules/no-array-index-key.md
+++ b/docs/rules/no-array-index-key.md
@@ -1,5 +1,7 @@
 # Disallow usage of Array index in keys (react/no-array-index-key)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 Warn if an element uses an Array index in its `key`.
 
 The `key` is used by React to [identify which items have changed, are added, or are removed and should be stable](https://facebook.github.io/react/docs/lists-and-keys.html#keys).

--- a/docs/rules/no-arrow-function-lifecycle.md
+++ b/docs/rules/no-arrow-function-lifecycle.md
@@ -1,5 +1,7 @@
 # Lifecycle methods should be methods on the prototype, not class fields (react/no-arrow-function-lifecycle)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 🔧 This rule is automatically fixable using the `--fix` [flag](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) on the command line.
 
 It is not necessary to use arrow function for lifecycle methods. This makes things harder to test, conceptually less performant (although in practice, performance will not be affected, since most engines will optimize efficiently), and can break hot reloading patterns.

--- a/docs/rules/no-children-prop.md
+++ b/docs/rules/no-children-prop.md
@@ -1,5 +1,7 @@
 # Disallow passing of children as props (react/no-children-prop)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`, `recommended`.
+
 Children should always be actual children, not passed in as a prop.
 
 When using JSX, the children should be nested between the opening and closing

--- a/docs/rules/no-danger-with-children.md
+++ b/docs/rules/no-danger-with-children.md
@@ -1,5 +1,7 @@
 # Disallow when a DOM element is using both children and dangerouslySetInnerHTML (react/no-danger-with-children)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`, `recommended`.
+
 This rule helps prevent problems caused by using children and the dangerouslySetInnerHTML prop at the same time.
 React will throw a warning if this rule is ignored.
 

--- a/docs/rules/no-danger.md
+++ b/docs/rules/no-danger.md
@@ -1,5 +1,7 @@
 # Disallow usage of dangerous JSX properties (react/no-danger)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 Dangerous properties in React are those whose behavior is known to be a common source of application vulnerabilities. The properties names clearly indicate they are dangerous and should be avoided unless great care is taken.
 
 See <https://facebook.github.io/react/tips/dangerously-set-inner-html.html>

--- a/docs/rules/no-deprecated.md
+++ b/docs/rules/no-deprecated.md
@@ -1,5 +1,7 @@
 # Disallow usage of deprecated methods (react/no-deprecated)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`, `recommended`.
+
 Several methods are deprecated between React versions. This rule will warn you if you try to use a deprecated method. Use the [shared settings](/README.md#configuration) to specify the React version.
 
 ## Rule Details

--- a/docs/rules/no-did-mount-set-state.md
+++ b/docs/rules/no-did-mount-set-state.md
@@ -1,5 +1,7 @@
 # Disallow usage of setState in componentDidMount (react/no-did-mount-set-state)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 Updating the state after a component mount will trigger a second `render()` call and can lead to property/layout thrashing.
 
 ## Rule Details

--- a/docs/rules/no-did-update-set-state.md
+++ b/docs/rules/no-did-update-set-state.md
@@ -1,5 +1,7 @@
 # Disallow usage of setState in componentDidUpdate (react/no-did-update-set-state)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 Updating the state after a component update will trigger a second `render()` call and can lead to property/layout thrashing.
 
 ## Rule Details

--- a/docs/rules/no-direct-mutation-state.md
+++ b/docs/rules/no-direct-mutation-state.md
@@ -1,5 +1,7 @@
 # Disallow direct mutation of this.state (react/no-direct-mutation-state)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`, `recommended`.
+
 NEVER mutate `this.state` directly, as calling `setState()` afterwards may replace
 the mutation you made. Treat `this.state` as if it were immutable.
 

--- a/docs/rules/no-find-dom-node.md
+++ b/docs/rules/no-find-dom-node.md
@@ -1,5 +1,7 @@
 # Disallow usage of findDOMNode (react/no-find-dom-node)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`, `recommended`.
+
 Facebook will eventually deprecate `findDOMNode` as it blocks certain improvements in React in the future.
 
 It is recommended to use callback refs instead. See [Dan Abramov comments and examples](https://github.com/jsx-eslint/eslint-plugin-react/issues/678#issue-165177220).

--- a/docs/rules/no-invalid-html-attribute.md
+++ b/docs/rules/no-invalid-html-attribute.md
@@ -1,5 +1,7 @@
 # Disallow usage of invalid attributes (react/no-invalid-html-attribute)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 🔧 This rule is automatically fixable using the `--fix` [flag](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) on the command line.
 
 Some HTML elements have a specific set of valid values for some attributes.

--- a/docs/rules/no-is-mounted.md
+++ b/docs/rules/no-is-mounted.md
@@ -1,5 +1,7 @@
 # Disallow usage of isMounted (react/no-is-mounted)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`, `recommended`.
+
 [`isMounted` is an anti-pattern][anti-pattern], is not available when using ES6 classes, and it is on its way to being officially deprecated.
 
 [anti-pattern]: https://facebook.github.io/react/blog/2015/12/16/ismounted-antipattern.html

--- a/docs/rules/no-multi-comp.md
+++ b/docs/rules/no-multi-comp.md
@@ -1,5 +1,7 @@
 # Disallow multiple component definition per file (react/no-multi-comp)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 Declaring only one component per file improves readability and reusability of components.
 
 ## Rule Details

--- a/docs/rules/no-namespace.md
+++ b/docs/rules/no-namespace.md
@@ -1,5 +1,7 @@
 # Enforce that namespaces are not used in React elements (react/no-namespace)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 Enforces the absence of a namespace in React elements, such as with `svg:circle`, as they are not supported in React.
 
 ## Rule Details

--- a/docs/rules/no-redundant-should-component-update.md
+++ b/docs/rules/no-redundant-should-component-update.md
@@ -1,5 +1,7 @@
 # Disallow usage of shouldComponentUpdate when extending React.PureComponent (react/no-redundant-should-component-update)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 Warns if you have `shouldComponentUpdate` defined when defining a component that extends React.PureComponent.
 While having `shouldComponentUpdate` will still work, it becomes pointless to extend PureComponent.
 

--- a/docs/rules/no-render-return-value.md
+++ b/docs/rules/no-render-return-value.md
@@ -1,5 +1,7 @@
 # Disallow usage of the return value of ReactDOM.render (react/no-render-return-value)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`, `recommended`.
+
 > `ReactDOM.render()` currently returns a reference to the root `ReactComponent` instance. However, using this return value is legacy and should be avoided because future versions of React may render components asynchronously in some cases. If you need a reference to the root `ReactComponent` instance, the preferred solution is to attach a [callback ref](https://reactjs.org/docs/refs-and-the-dom.html#callback-refs) to the root element.
 
 Source: [ReactDOM documentation](https://facebook.github.io/react/docs/react-dom.html#render)

--- a/docs/rules/no-set-state.md
+++ b/docs/rules/no-set-state.md
@@ -1,5 +1,7 @@
 # Disallow usage of setState (react/no-set-state)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 When using an architecture that separates your application state from your UI components (e.g. Flux), it may be desirable to forbid the use of local component state. This rule is especially helpful in read-only applications (that don't use forms), since local component state should rarely be necessary in such cases.
 
 ## Rule Details

--- a/docs/rules/no-string-refs.md
+++ b/docs/rules/no-string-refs.md
@@ -1,5 +1,7 @@
 # Disallow using string references (react/no-string-refs)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`, `recommended`.
+
 Currently, two ways are supported by React to refer to components. The first way, providing a string identifier, is now considered legacy in the official documentation. The documentation now prefers a second method -- referring to components by setting a property on the `this` object in the reference callback.
 
 ## Rule Details

--- a/docs/rules/no-this-in-sfc.md
+++ b/docs/rules/no-this-in-sfc.md
@@ -1,5 +1,7 @@
 # Disallow `this` from being used in stateless functional components (react/no-this-in-sfc)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 In React, there are two styles of component. One is a class component: `class Foo extends React.Component {...}`, which accesses its props, context, and state as properties of `this`: `this.props.foo`, etc. The other are stateless functional components (SFCs): `function Foo(props, context) {...}`. As you can see, there's no `state` (hence the name - hooks do not change this), and the props and context are provided as its two functional arguments. In an SFC, state is usually best implements with a [React hook](https://reactjs.org/docs/hooks-overview.html) such as `React.useState()`.
 
 Attempting to access properties on `this` can sometimes be valid, but it's very commonly an error caused by unfamiliarity with the differences between the two styles of components, or a missed reference when converting a class component to an SFC.

--- a/docs/rules/no-typos.md
+++ b/docs/rules/no-typos.md
@@ -1,5 +1,7 @@
 # Disallow common typos (react/no-typos)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 Ensure no casing typos were made declaring static class properties and lifecycle methods.
 Checks that declared `propTypes`, `contextTypes` and `childContextTypes` is supported by [react-props](https://github.com/facebook/prop-types)
 

--- a/docs/rules/no-unescaped-entities.md
+++ b/docs/rules/no-unescaped-entities.md
@@ -1,5 +1,7 @@
 # Disallow unescaped HTML entities from appearing in markup (react/no-unescaped-entities)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`, `recommended`.
+
 This rule prevents characters that you may have meant as JSX escape characters
 from being accidentally injected as a text node in JSX statements.
 

--- a/docs/rules/no-unknown-property.md
+++ b/docs/rules/no-unknown-property.md
@@ -1,5 +1,7 @@
 # Disallow usage of unknown DOM property (react/no-unknown-property)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`, `recommended`.
+
 🔧 This rule is automatically fixable using the `--fix` [flag](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) on the command line.
 
 In JSX all DOM properties and attributes should be camelCased to be consistent with standard JavaScript style. This can be a possible source of error if you are used to writing plain HTML.

--- a/docs/rules/no-unsafe.md
+++ b/docs/rules/no-unsafe.md
@@ -1,5 +1,7 @@
 # Disallow usage of unsafe lifecycle methods (react/no-unsafe)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`. This rule is disabled in the following configs: `recommended`.
+
 Certain legacy lifecycle methods are [unsafe for use in async React applications][async_rendering] and cause warnings in [_strict mode_][strict_mode]. These also happen to be the lifecycles that cause the most [confusion within the React community][component_lifecycle_changes].
 
 [async_rendering]: https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html

--- a/docs/rules/no-unstable-nested-components.md
+++ b/docs/rules/no-unstable-nested-components.md
@@ -1,5 +1,7 @@
 # Disallow creating unstable components inside components (react/no-unstable-nested-components)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 Creating components inside components without memoization leads to unstable components. The nested component and all its children are recreated during each re-render. Given stateful children of the nested component will lose their state on each re-render.
 
 React reconciliation performs element type comparison with [reference equality](https://github.com/facebook/react/blob/v16.13.1/packages/react-reconciler/src/ReactChildFiber.js#L407). The reference to the same element changes on each re-render when defining components inside the render block. This leads to complete recreation of the current node and all its children. As a result the virtual DOM has to do extra unnecessary work and [possible bugs are introduced](https://codepen.io/ariperkkio/pen/vYLodLB).

--- a/docs/rules/no-unused-class-component-methods.md
+++ b/docs/rules/no-unused-class-component-methods.md
@@ -1,5 +1,7 @@
 # Disallow declaring unused methods of component class (react/no-unused-class-component-methods)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 Warns you if you have defined a method or property but it is never being used anywhere.
 
 ## Rule Details

--- a/docs/rules/no-unused-prop-types.md
+++ b/docs/rules/no-unused-prop-types.md
@@ -1,5 +1,7 @@
 # Disallow definitions of unused propTypes (react/no-unused-prop-types)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 Warns if a prop with a defined type isn't being used.
 
 > **Note**: You can provide types in runtime types using [PropTypes] and/or

--- a/docs/rules/no-unused-state.md
+++ b/docs/rules/no-unused-state.md
@@ -1,5 +1,7 @@
 # Disallow definitions of unused state (react/no-unused-state)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 Warns you if you have defined a property on the state, but it is not being used anywhere.
 
 ## Rule Details

--- a/docs/rules/no-will-update-set-state.md
+++ b/docs/rules/no-will-update-set-state.md
@@ -1,5 +1,7 @@
 # Disallow usage of setState in componentWillUpdate (react/no-will-update-set-state)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 Updating the state during the componentWillUpdate step can lead to indeterminate component state and is not allowed.
 
 ## Rule Details

--- a/docs/rules/prefer-es6-class.md
+++ b/docs/rules/prefer-es6-class.md
@@ -1,5 +1,7 @@
 # Enforce ES5 or ES6 class for React Components (react/prefer-es6-class)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 React offers you two ways to create traditional components: using the ES5 `create-react-class` module or the new ES6 class system.
 
 ## Rule Details

--- a/docs/rules/prefer-exact-props.md
+++ b/docs/rules/prefer-exact-props.md
@@ -1,5 +1,7 @@
 # Prefer exact proptype definitions (react/prefer-exact-props)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 Recommends options to ensure only exact prop definitions are used when writing components. This recommends solutions for PropTypes or for Flow types.
 
 In React, you can define prop types for components using propTypes. Such an example is below:

--- a/docs/rules/prefer-read-only-props.md
+++ b/docs/rules/prefer-read-only-props.md
@@ -1,5 +1,7 @@
 # Enforce that props are read-only (react/prefer-read-only-props)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 🔧 This rule is automatically fixable using the `--fix` [flag](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) on the command line.
 
 Using Flow, one can define types for props. This rule enforces that prop types are read-only (covariant).

--- a/docs/rules/prefer-stateless-function.md
+++ b/docs/rules/prefer-stateless-function.md
@@ -1,5 +1,7 @@
 # Enforce stateless components to be written as a pure function (react/prefer-stateless-function)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 Stateless functional components are simpler than class based components and will benefit from future React performance optimizations specific to these components.
 
 ## Rule Details

--- a/docs/rules/prop-types.md
+++ b/docs/rules/prop-types.md
@@ -1,5 +1,7 @@
 # Disallow missing props validation in a React component definition (react/prop-types)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`, `recommended`.
+
 Defining types for component props improves reusability of your components by
 validating received data. It can warn other developers if they make a mistake while reusing the component with improper data type.
 

--- a/docs/rules/react-in-jsx-scope.md
+++ b/docs/rules/react-in-jsx-scope.md
@@ -1,5 +1,7 @@
 # Disallow missing React when using JSX (react/react-in-jsx-scope)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`, `recommended`. This rule is disabled in the following configs: `jsx-runtime`.
+
 When using JSX, `<a />` expands to `React.createElement("a")`. Therefore the `React` variable must be in scope.
 
 If you are using the @jsx pragma this rule will check the designated variable and not the `React` one.

--- a/docs/rules/require-default-props.md
+++ b/docs/rules/require-default-props.md
@@ -1,5 +1,7 @@
 # Enforce a defaultProps definition for every prop that is not a required prop (react/require-default-props)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 This rule aims to ensure that any non-required prop types of a component has a
 corresponding `defaultProps` value.
 

--- a/docs/rules/require-optimization.md
+++ b/docs/rules/require-optimization.md
@@ -1,5 +1,7 @@
 # Enforce React components to have a shouldComponentUpdate method (react/require-optimization)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 This rule prevents you from creating React components without declaring a `shouldComponentUpdate` method.
 
 ## Rule Details

--- a/docs/rules/require-render-return.md
+++ b/docs/rules/require-render-return.md
@@ -1,5 +1,7 @@
 # Enforce ES5 or ES6 class for returning value in render function (react/require-render-return)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`, `recommended`.
+
 When writing the `render` method in a component it is easy to forget to return the JSX content. This rule will warn if the `return` statement is missing.
 
 ## Rule Details

--- a/docs/rules/self-closing-comp.md
+++ b/docs/rules/self-closing-comp.md
@@ -1,5 +1,7 @@
 # Disallow extra closing tags for components without children (react/self-closing-comp)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 🔧 This rule is automatically fixable using the `--fix` [flag](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) on the command line.
 
 Components without children can be self-closed to avoid unnecessary extra closing tag.

--- a/docs/rules/sort-comp.md
+++ b/docs/rules/sort-comp.md
@@ -1,5 +1,7 @@
 # Enforce component methods order (react/sort-comp)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 🔧 This rule is automatically fixable using the [`sort-comp` transform](https://github.com/reactjs/react-codemod/blob/master/transforms/sort-comp.js) in [react-codemod](https://www.npmjs.com/package/react-codemod).
 
 When creating React components it is more convenient to always follow the same organisation for method order to help you easily find lifecycle methods, event handlers, etc.

--- a/docs/rules/sort-prop-types.md
+++ b/docs/rules/sort-prop-types.md
@@ -1,5 +1,7 @@
 # Enforce propTypes declarations alphabetical sorting (react/sort-prop-types)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 Some developers prefer to sort prop type declarations alphabetically to be able to find necessary declaration easier at the later time. Others feel that it adds complexity and becomes burden to maintain.
 
 ## Rule Details

--- a/docs/rules/state-in-constructor.md
+++ b/docs/rules/state-in-constructor.md
@@ -1,5 +1,7 @@
 # Enforce class component state initialization style (react/state-in-constructor)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 ## Rule Details
 
 This rule will enforce the state initialization style to be either in a constructor or with a class property.

--- a/docs/rules/static-property-placement.md
+++ b/docs/rules/static-property-placement.md
@@ -1,5 +1,7 @@
 # Enforces where React component static properties should be positioned. (react/static-property-placement)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 This rule allows you to enforce where `childContextTypes`, `contextTypes`, `contextType`, `defaultProps`, `displayName`,
 and `propTypes` are declared in an ES6 class.
 

--- a/docs/rules/style-prop-object.md
+++ b/docs/rules/style-prop-object.md
@@ -1,5 +1,7 @@
 # Enforce style prop value is an object (react/style-prop-object)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 Require that the value of the prop `style` be an object or a variable that is
 an object.
 

--- a/docs/rules/void-dom-elements-no-children.md
+++ b/docs/rules/void-dom-elements-no-children.md
@@ -1,5 +1,7 @@
 # Disallow void DOM elements (e.g. `<img />`, `<br />`) from receiving children (react/void-dom-elements-no-children)
 
+💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`.
+
 There are some HTML elements that are only self-closing (e.g. `img`, `br`, `hr`). These are collectively known as void DOM elements. If you try to give these children, React will give you a warning like:
 
 > Invariant Violation: img is a void element tag and must neither have `children` nor use `dangerouslySetInnerHTML`.

--- a/tests/index.js
+++ b/tests/index.js
@@ -5,6 +5,7 @@
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
+const arrayIncludes = require('array-includes');
 
 const plugin = require('..');
 
@@ -24,10 +25,29 @@ describe('all rule files should be exported by the plugin', () => {
 
 describe('rule documentation files have the correct content', () => {
   const MESSAGES = {
+    configs: '💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations):',
+    configsOff: 'This rule is disabled in the following configs:',
     deprecated: '❌ This rule is deprecated.',
     fixable: '🔧 This rule is automatically fixable using the `--fix` [flag](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) on the command line.',
     hasSuggestions: '💡 This rule provides editor [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).',
   };
+
+  function getConfigsForRule(ruleName, checkForEnabled) {
+    const configNames = [];
+    Object.keys(plugin.configs).forEach((configName) => {
+      const value = plugin.configs[configName].rules[`react/${ruleName}`];
+      const isOn = arrayIncludes([2, 'error'], value);
+      const isOff = arrayIncludes([0, 'off'], value);
+      if (value !== undefined && ((checkForEnabled && isOn) || (!checkForEnabled && isOff))) {
+        configNames.push(configName);
+      }
+    });
+    return configNames.sort();
+  }
+
+  function configNamesToList(configNames) {
+    return `\`${configNames.join('`, `')}\``;
+  }
 
   ruleFiles.forEach((ruleName) => {
     it(ruleName, () => {
@@ -45,8 +65,10 @@ describe('rule documentation files have the correct content', () => {
       const unexpectedNotices = [];
       if (rule.meta.deprecated) {
         expectedNotices.push('deprecated');
+        unexpectedNotices.push('configs');
       } else {
         unexpectedNotices.push('deprecated');
+        expectedNotices.push('configs');
       }
       if (rule.meta.fixable) {
         expectedNotices.push('fixable');
@@ -66,6 +88,15 @@ describe('rule documentation files have the correct content', () => {
         if (expectedNotice === 'deprecated' && documentLines[currentLineNumber + 1] !== MESSAGES[expectedNotice] && documentLines[currentLineNumber + 1].startsWith(MESSAGES[expectedNotice])) {
           // Allow additional rule-specific information at the end of the deprecation notice line.
           assert.ok(true, `includes ${expectedNotice} notice`);
+        } else if (expectedNotice === 'configs') {
+          // Check that the rule specifies its configs.
+          const configsOn = getConfigsForRule(ruleName, true);
+          let expectedMessage = `${MESSAGES.configs} ${configNamesToList(configsOn)}.`;
+          const configsOff = getConfigsForRule(ruleName, false);
+          if (configsOff.length > 0) {
+            expectedMessage += ` ${MESSAGES.configsOff} ${configNamesToList(configsOff)}.`;
+          }
+          assert.strictEqual(documentLines[currentLineNumber + 1], expectedMessage, 'includes configs notice');
         } else {
           // Otherwise, just check the whole line.
           assert.strictEqual(documentLines[currentLineNumber + 1], MESSAGES[expectedNotice], `includes ${expectedNotice} notice`);


### PR DESCRIPTION
This PR adds the following rule doc notice specifying what configs each rule belongs to.

* 💼 This rule is enabled in the following [configs](https://github.com/jsx-eslint/eslint-plugin-react#shareable-configurations): `all`, `recommended`.

For a few rules, the notice will also indicate when the rules are disabled by a particular config.

This improves usability by enabling users to clearly and easily find out if a rule is applying to their codebase given their configuration.

This notice is tested to ensure it isn't forgotten.

It's common for ESLint and many popular ESLint plugins to include a notice like this too. A couple examples:
* https://eslint.org/docs/latest/rules/no-unused-vars
* https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-modern-math-apis.md

