### PR TITLE
[Docs] Standardize deprecated rule notice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,9 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 * [Docs] [`jsx-no-target-blank`]: Fix link to link-type-noreferrer ([#3319][] @Luccasoli)
 * [Docs] document which rules provide suggestions ([#3359][] @bmish)
 * [Docs] Consistent rule descriptions and doc sections ([#3361][] @bmish)
+* [Docs] Standardize deprecated rule notice ([#3364][] @bmish)
 
+[#3364]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3364
 [#3361]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3361
 [#3359]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3359
 [#3355]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3355

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ Enable the rules that you would like to use.
 |  |  |  | [react/jsx-props-no-spreading](docs/rules/jsx-props-no-spreading.md) | Disallow JSX prop spreading |
 |  |  |  | [react/jsx-sort-default-props](docs/rules/jsx-sort-default-props.md) | Enforce defaultProps declarations alphabetical sorting |
 |  | 🔧 |  | [react/jsx-sort-props](docs/rules/jsx-sort-props.md) | Enforce props alphabetical sorting |
-|  | 🔧 |  | [react/jsx-space-before-closing](docs/rules/jsx-space-before-closing.md) | Enforce spacing before closing bracket in JSX |
+|  | 🔧 |  | [react/jsx-space-before-closing](docs/rules/jsx-space-before-closing.md) | Enforce spacing before closing bracket in JSX. ❌ This rule is deprecated. |
 |  | 🔧 |  | [react/jsx-tag-spacing](docs/rules/jsx-tag-spacing.md) | Enforce whitespace in and around the JSX opening and closing brackets |
 | ✔ |  |  | [react/jsx-uses-react](docs/rules/jsx-uses-react.md) | Disallow React to be incorrectly marked as unused |
 | ✔ |  |  | [react/jsx-uses-vars](docs/rules/jsx-uses-vars.md) | Disallow variables used in JSX to be incorrectly marked as unused |

--- a/docs/rules/jsx-space-before-closing.md
+++ b/docs/rules/jsx-space-before-closing.md
@@ -1,8 +1,8 @@
 # Enforce spacing before closing bracket in JSX (react/jsx-space-before-closing)
 
-🔧 This rule is automatically fixable using the `--fix` [flag](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) on the command line.
+❌ This rule is deprecated. Please use the `"beforeSelfClosing"` option of the [jsx-tag-spacing](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-tag-spacing.md) rule instead.
 
-**Deprecation notice**: This rule is deprecated. Please use the `"beforeSelfClosing"` option of the [jsx-tag-spacing](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-tag-spacing.md) rule instead.
+🔧 This rule is automatically fixable using the `--fix` [flag](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) on the command line.
 
 Enforce or forbid spaces before the closing bracket of self-closing JSX elements.
 

--- a/markdown.config.js
+++ b/markdown.config.js
@@ -14,7 +14,7 @@ const ruleTableRows = Object.keys(rules)
       fixable ? '🔧' : '',
       hasSuggestions ? '💡' : '',
       `[react/${id}](docs/rules/${id}.md)`,
-      docs.description,
+      `${docs.description}${meta.deprecated ? '. ❌ This rule is deprecated.' : ''}`,
     ].join(' | ');
   });
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -24,6 +24,7 @@ describe('all rule files should be exported by the plugin', () => {
 
 describe('rule documentation files have the correct content', () => {
   const MESSAGES = {
+    deprecated: '❌ This rule is deprecated.',
     fixable: '🔧 This rule is automatically fixable using the `--fix` [flag](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) on the command line.',
     hasSuggestions: '💡 This rule provides editor [suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).',
   };
@@ -42,6 +43,11 @@ describe('rule documentation files have the correct content', () => {
       // Decide which notices should be shown at the top of the doc.
       const expectedNotices = [];
       const unexpectedNotices = [];
+      if (rule.meta.deprecated) {
+        expectedNotices.push('deprecated');
+      } else {
+        unexpectedNotices.push('deprecated');
+      }
       if (rule.meta.fixable) {
         expectedNotices.push('fixable');
       } else {
@@ -57,7 +63,13 @@ describe('rule documentation files have the correct content', () => {
       let currentLineNumber = 1;
       expectedNotices.forEach((expectedNotice) => {
         assert.strictEqual(documentLines[currentLineNumber], '', `includes blank line ahead of ${expectedNotice} notice`);
-        assert.strictEqual(documentLines[currentLineNumber + 1], MESSAGES[expectedNotice], `includes ${expectedNotice} notice`);
+        if (expectedNotice === 'deprecated' && documentLines[currentLineNumber + 1] !== MESSAGES[expectedNotice] && documentLines[currentLineNumber + 1].startsWith(MESSAGES[expectedNotice])) {
+          // Allow additional rule-specific information at the end of the deprecation notice line.
+          assert.ok(true, `includes ${expectedNotice} notice`);
+        } else {
+          // Otherwise, just check the whole line.
+          assert.strictEqual(documentLines[currentLineNumber + 1], MESSAGES[expectedNotice], `includes ${expectedNotice} notice`);
+        }
         currentLineNumber += 2;
       });
 


### PR DESCRIPTION
```
❌ This rule is deprecated.
```


* Standardize deprecation notice in rule docs to be more consistent with the other rule notices and add a test that it's present for deprecated rules. Note that rule-specific deprecation information is allowed at the end of the line for this notice.
* In the README rules list, mention if a rule is deprecated next to its description. Note that I chose not to add a deprecation column like the other columns we have for recommended/fixable/suggestable because I didn't want to waste more horizontal width on this for something that is probably rare. We can always switch to a separate column in the future if needed.


Extracted from this PR: #3362