### PR TITLE
Allows using undefined or empty string for fixer

### DIFF
--- a/lib/rules/jsx-no-leaked-render.js
+++ b/lib/rules/jsx-no-leaked-render.js
@@ -19,6 +19,7 @@ const messages = {
 
 const COERCE_STRATEGY = 'coerce';
 const TERNARY_STRATEGY = 'ternary';
+const DEFAULT_TERNARY_REPLACE_VALUE = null; // null, undefined, ''
 const DEFAULT_VALID_STRATEGIES = [TERNARY_STRATEGY, COERCE_STRATEGY];
 const COERCE_VALID_LEFT_SIDE_EXPRESSIONS = ['UnaryExpression', 'BinaryExpression', 'CallExpression'];
 const TERNARY_INVALID_ALTERNATE_VALUES = [undefined, null, false];
@@ -49,7 +50,7 @@ function extractExpressionBetweenLogicalAnds(node) {
   );
 }
 
-function ruleFixer(context, fixStrategy, fixer, reportedNode, leftNode, rightNode) {
+function ruleFixer(context, fixStrategy, ternaryReplaceValue, fixer, reportedNode, leftNode, rightNode) {
   const sourceCode = context.getSourceCode();
   const rightSideText = sourceCode.getText(rightNode);
 
@@ -71,7 +72,7 @@ function ruleFixer(context, fixStrategy, fixer, reportedNode, leftNode, rightNod
     if (isParenthesized(context, leftNode)) {
       leftSideText = `(${leftSideText})`;
     }
-    return fixer.replaceText(reportedNode, `${leftSideText} ? ${rightSideText} : null`);
+    return fixer.replaceText(reportedNode, `${leftSideText} ? ${rightSideText} : ${ternaryReplaceValue}`);
   }
 
   throw new TypeError('Invalid value for "validStrategies" option');
@@ -107,6 +108,10 @@ module.exports = {
             uniqueItems: true,
             default: DEFAULT_VALID_STRATEGIES,
           },
+          ternaryReplaceValue: {
+            type: ['null', 'object', 'string'],
+            default: DEFAULT_TERNARY_REPLACE_VALUE,
+          },
         },
         additionalProperties: false,
       },
@@ -117,6 +122,7 @@ module.exports = {
     const config = context.options[0] || {};
     const validStrategies = new Set(config.validStrategies || DEFAULT_VALID_STRATEGIES);
     const fixStrategy = Array.from(validStrategies)[0];
+    const ternaryReplaceValue = config.ternaryReplaceValue || DEFAULT_TERNARY_REPLACE_VALUE;
 
     return {
       'JSXExpressionContainer > LogicalExpression[operator="&&"]'(node) {
@@ -133,7 +139,7 @@ module.exports = {
         report(context, messages.noPotentialLeakedRender, 'noPotentialLeakedRender', {
           node,
           fix(fixer) {
-            return ruleFixer(context, fixStrategy, fixer, node, leftSide, node.right);
+            return ruleFixer(context, fixStrategy, ternaryReplaceValue, fixer, node, leftSide, node.right);
           },
         });
       },
@@ -152,7 +158,7 @@ module.exports = {
         report(context, messages.noPotentialLeakedRender, 'noPotentialLeakedRender', {
           node,
           fix(fixer) {
-            return ruleFixer(context, fixStrategy, fixer, node, node.test, node.consequent);
+            return ruleFixer(context, fixStrategy, ternaryReplaceValue, fixer, node, node.test, node.consequent);
           },
         });
       },

--- a/lib/rules/jsx-no-leaked-render.js
+++ b/lib/rules/jsx-no-leaked-render.js
@@ -19,7 +19,7 @@ const messages = {
 
 const COERCE_STRATEGY = 'coerce';
 const TERNARY_STRATEGY = 'ternary';
-const DEFAULT_TERNARY_REPLACE_VALUE = null; // null, undefined, ''
+const DEFAULT_TERNARY_REPLACE_VALUE = null;
 const DEFAULT_VALID_STRATEGIES = [TERNARY_STRATEGY, COERCE_STRATEGY];
 const COERCE_VALID_LEFT_SIDE_EXPRESSIONS = ['UnaryExpression', 'BinaryExpression', 'CallExpression'];
 const TERNARY_INVALID_ALTERNATE_VALUES = [undefined, null, false];


### PR DESCRIPTION
jsx-no-leaked-render ternary fixes the error with `null`.

Some codebases disable the use of `null` and only use `undefined`, alternatively some developers may choose to use an empty string.

This commit allows configuring that.