### PR TITLE
Don't add markdownlint config to NPM package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 
 ## Unreleased
 
+### Changed
+
+* [Meta] npmignore markdownlint config ([#3413][] @jorrit)
+
+[#3413]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3413
+
 ## [7.31.7] - 2022.09.05
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -95,7 +95,8 @@
       "*.config.js",
       ".eslintrc",
       ".editorconfig",
-      "tsconfig.json"
+      "tsconfig.json",
+      ".markdownlint*"
     ]
   }
 }


### PR DESCRIPTION
Perhaps a `"files"` key in package.json is a better idea than expanding the `"ignore"` list again. But I'll leave that to the maintainer.