### PR TITLE
[Fix] `no-unknown-property`: allow `abbr` on `<th>` and `<td>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,13 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 * [`no-unknown-property`]: add `noModule` on `script` ([#3414][] @ljharb)
 * [`no-unknown-property`]: allow `onLoad` on `<object>` ([#3415][] @OleksiiKachan)
 * [`no-multi-comp`]: do not detect a function property returning only null as a component ([#3412][] @ljharb)
+* [`no-unknown-property`]: allow `abbr` on `<th>` and `<td>` ([#3419][] @OleksiiKachan)
 
 ### Changed
 
 * [Meta] npmignore markdownlint config ([#3413][] @jorrit)
 
+[#3419]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3419
 [#3416]: https://github.com/jsx-eslint/eslint-plugin-react/issues/3416
 [#3415]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3415
 [#3414]: https://github.com/jsx-eslint/eslint-plugin-react/issues/3414

--- a/lib/rules/no-unknown-property.js
+++ b/lib/rules/no-unknown-property.js
@@ -28,6 +28,7 @@ const DOM_ATTRIBUTE_NAMES = {
 };
 
 const ATTRIBUTE_TAGS_MAP = {
+  abbr: ['th', 'td'],
   checked: ['input'],
   // image is required for SVG support, all other tags are HTML.
   crossOrigin: ['script', 'img', 'video', 'audio', 'link', 'image'],

--- a/tests/lib/rules/no-unknown-property.js
+++ b/tests/lib/rules/no-unknown-property.js
@@ -69,6 +69,8 @@ ruleTester.run('no-unknown-property', rule, {
     { code: '<object onLoad={bar} />' },
     { code: '<div allowFullScreen webkitAllowFullScreen mozAllowFullScreen />' },
     { code: '<table border="1" />' },
+    { code: '<th abbr="abbr" />' },
+    { code: '<td abbr="abbr" />' },
     {
       code: '<div allowTransparency="true" />',
       settings: {
@@ -545,6 +547,19 @@ ruleTester.run('no-unknown-property', rule, {
           messageId: 'unknownProp',
           data: {
             name: 'data-xml-anything',
+          },
+        },
+      ],
+    },
+    {
+      code: '<div abbr="abbr" />',
+      errors: [
+        {
+          messageId: 'invalidPropOnTag',
+          data: {
+            name: 'abbr',
+            tagName: 'div',
+            allowedTags: 'th, td',
           },
         },
       ],


### PR DESCRIPTION
Fixes #3418

[https://www.w3resource.com/html/attributes/html-abbr-attribute.php]()