### PR TITLE
[Docs] `no-unknown-property`: fix typo in link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 * [`no-arrow-function-lifecycle`]: when converting from an arrow, remove the semi and wrapping parens ([#3337][] @ljharb)
 * [`jsx-key`]: Ignore elements inside `React.Children.toArray()` ([#1591][] @silvenon)
 
+### Changed
+* [Docs] [`no-unknown-property`]: fix typo in link ([#3445][] @denkristoffer)
+
+[#3445]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3445
 [#3436]: https://github.com/jsx-eslint/eslint-plugin-react/issues/3436
 [#3337]: https://github.com/jsx-eslint/eslint-plugin-react/issues/3337
 [#1591]: https://github.com/jsx-eslint/eslint-plugin-react/pull/1591

--- a/docs/rules/no-unknown-property.md
+++ b/docs/rules/no-unknown-property.md
@@ -58,7 +58,7 @@ var AtomPanel = <atom-panel class="foo"></atom-panel>;
 
 If you are using a library that passes something as a prop to JSX elements, it is recommended to add those props to the ignored properties.
 
-For example, if you use [emotion](https://emotion.sh/docs/introduction) and its [`css` prop](https://emotion.sh/docs/css-prop)),
+For example, if you use [emotion](https://emotion.sh/docs/introduction) and its [`css` prop](https://emotion.sh/docs/css-prop),
 add the following to your `.eslintrc` config file:
 
 ```js


### PR DESCRIPTION
Removes a parenthesis in the link to emotion's CSS prop docs.