### PR TITLE
[Fix] `jsx-no-constructed-context-values`: fix false positive for usage in non-components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,12 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 * [`no-unknown-property`]: add `dialog` attributes ([#3436][] @ljharb)
 * [`no-arrow-function-lifecycle`]: when converting from an arrow, remove the semi and wrapping parens ([#3337][] @ljharb)
 * [`jsx-key`]: Ignore elements inside `React.Children.toArray()` ([#1591][] @silvenon)
+* [`jsx-no-constructed-context-values`]: fix false positive for usage in non-components ([#3448][] @golopot)
 
 ### Changed
 * [Docs] [`no-unknown-property`]: fix typo in link ([#3445][] @denkristoffer)
 
+[#3448]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3448
 [#3445]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3445
 [#3436]: https://github.com/jsx-eslint/eslint-plugin-react/issues/3436
 [#3337]: https://github.com/jsx-eslint/eslint-plugin-react/issues/3337

--- a/lib/rules/jsx-no-constructed-context-values.js
+++ b/lib/rules/jsx-no-constructed-context-values.js
@@ -6,6 +6,7 @@
 
 'use strict';
 
+const Components = require('../util/Components');
 const docsUrl = require('../util/docsUrl');
 const report = require('../util/report');
 
@@ -139,7 +140,8 @@ module.exports = {
     messages,
   },
 
-  create(context) {
+  // eslint-disable-next-line arrow-body-style
+  create: Components.detect((context, components, utils) => {
     return {
       JSXOpeningElement(node) {
         const openingElementName = node.name;
@@ -184,6 +186,10 @@ module.exports = {
           return;
         }
 
+        if (!utils.getParentComponent(node)) {
+          return;
+        }
+
         // Report found error
         const constructType = constructInfo.type;
         const constructNode = constructInfo.node;
@@ -214,5 +220,5 @@ module.exports = {
         });
       },
     };
-  },
+  }),
 };

--- a/tests/lib/rules/jsx-no-constructed-context-values.js
+++ b/tests/lib/rules/jsx-no-constructed-context-values.js
@@ -31,13 +31,13 @@ const ruleTester = new RuleTester({ parserOptions });
 ruleTester.run('react-no-constructed-context-values', rule, {
   valid: parsers.all([
     {
-      code: '<Context.Provider value={props}></Context.Provider>',
+      code: 'const Component = () => <Context.Provider value={props}></Context.Provider>',
     },
     {
-      code: '<Context.Provider value={100}></Context.Provider>',
+      code: 'const Component = () => <Context.Provider value={100}></Context.Provider>',
     },
     {
-      code: '<Context.Provider value="Some string"></Context.Provider>',
+      code: 'const Component = () => <Context.Provider value="Some string"></Context.Provider>',
     },
     {
       code: 'function Component() { const foo = useMemo(() => { return {} }, []); return (<Context.Provider value={foo}></Context.Provider>)}',
@@ -135,6 +135,16 @@ ruleTester.run('react-no-constructed-context-values', rule, {
                 </BooleanContext.Provider>
             )
         }
+      `,
+    },
+    {
+      code: `
+        const root = ReactDOM.createRoot(document.getElementById('root'));
+        root.render(
+          <AppContext.Provider value={{}}>
+            <AppView />
+          </AppContext.Provider>
+        );
       `,
     },
   ]),


### PR DESCRIPTION
Fixes #3295