### PR TITLE
[Perf] improve performance for rules using isCreateElement

### DIFF
--- a/lib/util/isCreateElement.js
+++ b/lib/util/isCreateElement.js
@@ -10,13 +10,12 @@ const isDestructuredFromPragmaImport = require('./isDestructuredFromPragmaImport
  * @returns {Boolean} - True if node is a createElement call object literal, False if not.
 */
 module.exports = function isCreateElement(node, context) {
-  const pragma = pragmaUtil.getFromContext(context);
   if (
     node.callee
     && node.callee.type === 'MemberExpression'
     && node.callee.property.name === 'createElement'
     && node.callee.object
-    && node.callee.object.name === pragma
+    && node.callee.object.name === pragmaUtil.getFromContext(context)
   ) {
     return true;
   }


### PR DESCRIPTION
This change makes `eslint .` run about 4% faster by optimizing `isCreateElement`.

![Screenshot from 2022-10-06 02-13-27](https://user-images.githubusercontent.com/16285118/194133096-84e4491b-b2ec-438b-9ba6-239bb564cf50.png)


![Screenshot from 2022-10-06 02-15-39](https://user-images.githubusercontent.com/16285118/194133103-7d5263ce-f4a5-4084-81ab-a1ed46923bd4.png)
