### PR TITLE
[Fix] `sort-prop-types`: avoid crash when autofixing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 
 ### Fixed
 * configs: avoid legacy config system error ([#3461][] @ljharb)
-* [`sort-prop-types`]: restore autofixing ([#3452][] @ROSSROSALES)
+* [`sort-prop-types`]: restore autofixing ([#3452][], [#3471][] @ROSSROSALES)
 * [`no-unknown-property`]: do not check `fbs` elements ([#3494][] @brianogilvie)
 * [`jsx-newline`]: No newline between comments and jsx elements ([#3493][] @justmejulian)
 * [`jsx-no-leaked-render`]: Don't report errors on empty strings if React >= v18 ([#3488][] @himanshu007-creator)
@@ -24,6 +24,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 [#3494]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3494
 [#3493]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3493
 [#3488]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3488
+[#3471]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3471
 [#3468]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3468
 [#3461]: https://github.com/jsx-eslint/eslint-plugin-react/issues/3461
 [#3452]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3452

--- a/docs/rules/sort-prop-types.md
+++ b/docs/rules/sort-prop-types.md
@@ -4,6 +4,8 @@
 
 <!-- end auto-generated rule header -->
 
+🔧 This rule is automatically fixable using the `--fix` [flag](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix) on the command line.
+
 Some developers prefer to sort prop type declarations alphabetically to be able to find necessary declaration easier at the later time. Others feel that it adds complexity and becomes burden to maintain.
 
 ## Rule Details

--- a/lib/util/propTypesSort.js
+++ b/lib/util/propTypesSort.js
@@ -127,29 +127,27 @@ function fixPropTypesSort(fixer, context, declarations, ignoreCase, requiredFirs
       const node = allNodes[i];
       let commentAfter = [];
       let commentBefore = [];
+      let newStart = 0;
+      let newEnd = 0;
       try {
         commentBefore = sourceCode.getCommentsBefore(node);
         commentAfter = sourceCode.getCommentsAfter(node);
       } catch (e) { /**/ }
-      if (commentAfter.length === 0 && commentBefore.length === 0) {
-        commentnodeMap.set(node, { start: node.range[0], end: node.range[1], hasComment: false });
-      } else {
-        const firstCommentBefore = commentBefore[0];
-        if (commentBefore.length === 1) {
-          commentnodeMap.set(node, { start: firstCommentBefore.range[0], end: node.range[1], hasComment: true });
-        }
-        const firstCommentAfter = commentAfter[0];
-        if (commentAfter.length === 1) {
-          commentnodeMap.set(node, { start: node.range[0], end: firstCommentAfter.range[1], hasComment: true });
-        }
-        if (commentBefore.length === 1 && commentAfter.length === 1) {
-          commentnodeMap.set(node, {
-            start: firstCommentBefore.range[0],
-            end: firstCommentAfter.range[1],
-            hasComment: true,
-          });
-        }
+
+      if (commentAfter.length === 0 || commentBefore.length === 0) {
+        newStart = node.range[0];
+        newEnd = node.range[1];
       }
+
+      const firstCommentBefore = commentBefore[0];
+      if (commentBefore.length >= 1) {
+        newStart = firstCommentBefore.range[0];
+      }
+      const lastCommentAfter = commentAfter[commentAfter.length - 1];
+      if (commentAfter.length >= 1) {
+        newEnd = lastCommentAfter.range[1];
+      }
+      commentnodeMap.set(node, { start: newStart, end: newEnd, hasComment: true });
     }
     const nodeGroups = allNodes.reduce((acc, curr) => {
       if (curr.type === 'ExperimentalSpreadProperty' || curr.type === 'SpreadElement') {

--- a/tests/lib/rules/sort-prop-types.js
+++ b/tests/lib/rules/sort-prop-types.js
@@ -2098,6 +2098,56 @@ ruleTester.run('sort-prop-types', rule, {
           type: 'Property',
         },
       ],
+    } : [],
+    semver.satisfies(eslintPkg.version, '> 3') ? {
+      code: `
+        var First = createReactClass({
+          propTypes: {
+            /* z */
+            /* z */
+            z: PropTypes.string /* z */,
+            /* a */
+            a: PropTypes.any /* a */
+            /* a */
+            /* a */,
+            b: PropTypes.any
+          },
+          render: function() {
+            return <div />;
+          }
+        });
+      `,
+      output: `
+        var First = createReactClass({
+          propTypes: {
+            /* a */
+            a: PropTypes.any /* a */
+            /* a */
+            /* a */,
+            b: PropTypes.any,
+            /* z */
+            /* z */
+            z: PropTypes.string /* z */
+          },
+          render: function() {
+            return <div />;
+          }
+        });
+      `,
+      errors: [
+        {
+          messageId: 'propsNotSorted',
+          line: 8,
+          column: 13,
+          type: 'Property',
+        },
+        {
+          messageId: 'propsNotSorted',
+          line: 11,
+          column: 13,
+          type: 'Property',
+        },
+      ],
     } : []
   )),
 });


### PR DESCRIPTION
Fixes https://github.com/jsx-eslint/eslint-plugin-react/issues/3470

Now rule respects multiple comments before and after prop.
Fixes issue of no comments before and after prop not being considered during parsing.