### PR TITLE
docs: inclusive language w/ allowlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 
 ### Changed
 * [Perf] component detection: improve performance by avoiding traversing parents unnecessarily ([#3459][] @golopot)
+* [Docs] `forbid-component-props`: inclusive language w/ allowlist ([#3473][] @AndersDJohnson)
 
+[#3473]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3473
 [#3464]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3464
 [#3461]: https://github.com/jsx-eslint/eslint-plugin-react/issues/3461
 [#3459]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3459

--- a/docs/rules/forbid-component-props.md
+++ b/docs/rules/forbid-component-props.md
@@ -45,7 +45,7 @@ Examples of **correct** code for this rule:
 
 An array specifying the names of props that are forbidden. The default value of this option is `['className', 'style']`.
 Each array element can either be a string with the property name or object specifying the property name, an optional
-custom message, and a component whitelist:
+custom message, and a component allowlist:
 
 ```js
 {


### PR DESCRIPTION
Hello! Love this plugin! Just noticed an opportunity to make the language a bit more inclusive in the docs for the rule `forbid-component-props` by switching to the term "allowlist", as other projects have been doing lately. Up to the maintainers though! Thanks.

Side note: Have we considered opting this repository into Hacktoberfest? Simply adding the `hacktoberfest` topic to the repo will allow contributors to get credit for their changes! https://hacktoberfest.com/participation/ Thanks again!