### PR TITLE
[Fix] `no-unknown-property`: do not check `fbs` elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 ### Fixed
 * configs: avoid legacy config system error ([#3461][] @ljharb)
 * [`sort-prop-types`]: restore autofixing ([#3452][] @ROSSROSALES)
+* [`no-unknown-property`]: do not check `fbs` elements ([#3494][] @brianogilvie)
 
+[#3494]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3494
 [#3461]: https://github.com/jsx-eslint/eslint-plugin-react/issues/3461
 [#3452]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3452
 [#3449]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3449

--- a/lib/rules/no-unknown-property.js
+++ b/lib/rules/no-unknown-property.js
@@ -544,7 +544,7 @@ module.exports = {
 
         const tagName = getTagName(node);
 
-        if (tagName === 'fbt') { return; } // fbt nodes are bonkers, let's not go there
+        if (tagName === 'fbt' || tagName === 'fbs') { return; } // fbt/fbs nodes are bonkers, let's not go there
 
         if (!isValidHTMLTagInJSX(node)) { return; }
 

--- a/tests/lib/rules/no-unknown-property.js
+++ b/tests/lib/rules/no-unknown-property.js
@@ -153,6 +153,8 @@ ruleTester.run('no-unknown-property', rule, {
 
     // fbt
     { code: '<fbt desc="foo" doNotExtract />;' },
+    // fbs
+    { code: '<fbs desc="foo" doNotExtract />;' },
   ]),
   invalid: parsers.all([
     {


### PR DESCRIPTION
Currently `<fbs>` nodes are tagged with this linter warning:

```
Unknown property 'desc' foundNuclide-ESLint[react/no-unknown-property](https://www.internalfb.com/intern/bunny?q%3Deslint%2Breact%2Fno-unknown-property)
```

`<fbt>` nodes are already exempt from this lint rule, and `<fbs>` should be treated the same. 

Internal WP discussion: https://fb.workplace.com/groups/eslintfeedback/permalink/6064426636924059/