### PR TITLE
[Fix] : Added global event listeners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 * add [`no-object-type-as-default-prop`] rule ([#2848][] @cyan33 @fengkx)
 
 ### Fixed
+* [`no-unknown-property`]: Added global event listeners ([#3505][] @axlemax)
 * configs: avoid legacy config system error ([#3461][] @ljharb)
 * [`sort-prop-types`]: restore autofixing ([#3452][], [#3471][] @ROSSROSALES)
 * [`no-unknown-property`]: do not check `fbs` elements ([#3494][] @brianogilvie)

--- a/docs/rules/no-unknown-property.md
+++ b/docs/rules/no-unknown-property.md
@@ -7,7 +7,7 @@
 <!-- end auto-generated rule header -->
 
 In JSX most DOM properties and attributes should be camelCased to be consistent with standard JavaScript style. This can be a possible source of error if you are used to writing plain HTML.
-Only `data-*` and `aria-*` attributes are usings hyphens and lowercase letters in JSX.
+Only `data-*` and `aria-*` attributes use hyphens and lowercase letters in JSX. Some props that may appear valid in React will actually not be applied as expected, which this rule helps to avoid.
 
 ## Rule Details
 

--- a/lib/rules/no-unknown-property.js
+++ b/lib/rules/no-unknown-property.js
@@ -69,33 +69,10 @@ const ATTRIBUTE_TAGS_MAP = {
   align: ['applet', 'caption', 'col', 'colgroup', 'hr', 'iframe', 'img', 'table', 'tbody', 'td', 'tfoot', 'th', 'thead', 'tr'], // deprecated, but known
   valign: ['tr', 'td', 'th', 'thead', 'tbody', 'tfoot', 'colgroup', 'col'], // deprecated, but known
   noModule: ['script'],
-  // Media events allowed only on audio and video tags, see https://github.com/facebook/react/blob/256aefbea1449869620fb26f6ec695536ab453f5/CHANGELOG.md#notable-enhancements
-  onAbort: ['audio', 'video'],
-  onCancel: ['dialog'],
-  onCanPlay: ['audio', 'video'],
-  onCanPlayThrough: ['audio', 'video'],
-  onClose: ['dialog'],
-  onDurationChange: ['audio', 'video'],
-  onEmptied: ['audio', 'video'],
+  // Note: Most events can be added to any HTML element, even if not specified in the standard
+  // see https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes
   onEncrypted: ['audio', 'video'],
-  onEnded: ['audio', 'video'],
-  onError: ['audio', 'video', 'img', 'link', 'source', 'script', 'picture', 'iframe'],
-  onLoad: ['script', 'img', 'link', 'picture', 'iframe', 'object'],
-  onLoadedData: ['audio', 'video'],
-  onLoadedMetadata: ['audio', 'video'],
-  onLoadStart: ['audio', 'video'],
-  onPause: ['audio', 'video'],
-  onPlay: ['audio', 'video'],
-  onPlaying: ['audio', 'video'],
-  onProgress: ['audio', 'video'],
-  onRateChange: ['audio', 'video'],
-  onSeeked: ['audio', 'video'],
-  onSeeking: ['audio', 'video'],
-  onStalled: ['audio', 'video'],
-  onSuspend: ['audio', 'video'],
-  onTimeUpdate: ['audio', 'video'],
-  onVolumeChange: ['audio', 'video'],
-  onWaiting: ['audio', 'video'],
+  onToggle: ['details'],
   autoPictureInPicture: ['video'],
   controls: ['audio', 'video'],
   controlsList: ['audio', 'video'],
@@ -112,6 +89,19 @@ const ATTRIBUTE_TAGS_MAP = {
   scrolling: ['iframe'],
   returnValue: ['dialog'],
   webkitDirectory: ['input'],
+};
+
+// Properties that are valid on all elements except specified ones
+const ATTRIBUTES_WITH_EXCLUSIONS = {
+  // Global event listeners not allowed on specific elements
+  // See https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers-on-elements,-document-objects,-and-window-objects
+  onBlur: ['body', 'frameset'],
+  onError: ['body', 'frameset'],
+  onFocus: ['body', 'frameset'],
+  onLoad: ['body', 'frameset'],
+  onResize: ['body', 'frameset'],
+  onScroll: ['body', 'frameset'],
+  onScrollEnd: ['body', 'frameset'],
 };
 
 const SVGDOM_ATTRIBUTE_NAMES = {
@@ -240,18 +230,49 @@ const DOM_PROPERTY_NAMES_TWO_WORDS = [
   // See https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes
   'accessKey', 'autoCapitalize', 'autoFocus', 'contentEditable', 'enterKeyHint', 'exportParts',
   'inputMode', 'itemID', 'itemRef', 'itemProp', 'itemScope', 'itemType', 'spellCheck', 'tabIndex',
+  // Global event listeners, can be used on any HTML/DOM element
+  // see https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers-on-elements,-document-objects,-and-window-objects
+  // and corresponding React types at https://github.com/DefinitelyTyped/DefinitelyTyped/blob/cfb0dca6417b441c600ce87922739bae4ef35164/types/react/index.d.ts#LL1375C11-L1375C11
+  'onAbort', 'onAbortCapture', 'onAnimationEnd', 'onAnimationEndCapture', 'onAnimationIteration',
+  'onAnimationIterationCapture', 'onAnimationStart', 'onAnimationStartCapture', 'onAuxClick',
+  'onAuxClickCapture', 'onBeforeInput', 'onBeforeInputCapture', 'onBlur', 'onBlurCapture',
+  'onCanPlay', 'onCanPlayCapture', 'onCanPlayThrough', 'onCanPlayThroughCapture', 'onChange',
+  'onChangeCapture', 'onClick', 'onClickCapture', 'onCompositionEnd', 'onCompositionEndCapture',
+  'onCompositionStart', 'onCompositionStartCapture', 'onCompositionUpdate',
+  'onCompositionUpdateCapture', 'onContextMenu', 'onContextMenuCapture', 'onCopy', 'onCopyCapture',
+  'onCut', 'onCutCapture', 'onDoubleClick', 'onDoubleClickCapture', 'onDrag', 'onDragCapture',
+  'onDragEnd', 'onDragEndCapture', 'onDragEnter', 'onDragEnterCapture', 'onDragExit',
+  'onDragExitCapture', 'onDragLeave', 'onDragLeaveCapture', 'onDragOver', 'onDragOverCapture',
+  'onDragStart', 'onDragStartCapture', 'onDrop', 'onDropCapture', 'onDurationChange',
+  'onDurationChangeCapture', 'onEmptied', 'onEmptiedCapture', 'onEncrypted', 'onEncryptedCapture',
+  'onEnded', 'onEndedCapture', 'onError', 'onErrorCapture', 'onFocus', 'onFocusCapture',
+  'onGotPointerCapture', 'onGotPointerCaptureCapture', 'onInput', 'onInputCapture', 'onInvalid',
+  'onInvalidCapture', 'onKeyDown', 'onKeyDownCapture', 'onKeyPress', 'onKeyPressCapture',
+  'onKeyUp', 'onKeyUpCapture', 'onLoad', 'onLoadCapture', 'onLoadedData', 'onLoadedDataCapture',
+  'onLoadedMetadata', 'onLoadedMetadataCapture', 'onLoadStart', 'onLoadStartCapture',
+  'onLostPointerCapture', 'onLostPointerCaptureCapture', 'onMouseDown', 'onMouseDownCapture',
+  'onMouseEnter', 'onMouseLeave', 'onMouseMove', 'onMouseMoveCapture', 'onMouseOut',
+  'onMouseOutCapture', 'onMouseOver', 'onMouseOverCapture', 'onMouseUp', 'onMouseUpCapture',
+  'onPaste', 'onPasteCapture', 'onPause', 'onPauseCapture', 'onPlay', 'onPlayCapture', 'onPlaying',
+  'onPlayingCapture', 'onPointerCancel', 'onPointerCancelCapture', 'onPointerDown',
+  'onPointerDownCapture', 'onPointerEnter', 'onPointerEnterCapture', 'onPointerLeave',
+  'onPointerLeaveCapture', 'onPointerMove', 'onPointerMoveCapture', 'onPointerOut',
+  'onPointerOutCapture', 'onPointerOver', 'onPointerOverCapture', 'onPointerUp',
+  'onPointerUpCapture', 'onProgress', 'onProgressCapture', 'onRateChange', 'onRateChangeCapture',
+  'onReset', 'onResetCapture', 'onScroll', 'onScrollCapture', 'onSeeked', 'onSeekedCapture',
+  'onSeeking', 'onSeekingCapture', 'onSelect', 'onSelectCapture', 'onStalled', 'onStalledCapture',
+  'onSubmit', 'onSubmitCapture', 'onSuspend', 'onSuspendCapture', 'onTimeUpdate',
+  'onTimeUpdateCapture', 'onTouchCancel', 'onTouchCancelCapture', 'onTouchEnd', 'onTouchEndCapture', 'onTouchMove',
+  'onTouchMoveCapture', 'onTouchStart', 'onTouchStartCapture', 'onTransitionEnd',
+  'onTransitionEndCapture', 'onVolumeChange', 'onVolumeChangeCapture', 'onWaiting',
+  'onWaitingCapture', 'onWheel', 'onWheelCapture',
   // Element specific attributes
   // See https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes (includes global attributes too)
   // To be considered if these should be added also to ATTRIBUTE_TAGS_MAP
   'acceptCharset', 'autoComplete', 'autoPlay', 'border', 'cellPadding', 'cellSpacing', 'classID', 'codeBase',
   'colSpan', 'contextMenu', 'dateTime', 'encType', 'formAction', 'formEncType', 'formMethod', 'formNoValidate', 'formTarget',
   'frameBorder', 'hrefLang', 'httpEquiv', 'imageSizes', 'imageSrcSet', 'isMap', 'keyParams', 'keyType', 'marginHeight', 'marginWidth',
-  'maxLength', 'mediaGroup', 'minLength', 'noValidate', 'onAnimationEnd', 'onAnimationIteration', 'onAnimationStart',
-  'onBlur', 'onChange', 'onClick', 'onContextMenu', 'onCopy', 'onCompositionEnd', 'onCompositionStart',
-  'onCompositionUpdate', 'onCut', 'onDoubleClick', 'onDrag', 'onDragEnd', 'onDragEnter', 'onDragExit', 'onDragLeave',
-  'onError', 'onFocus', 'onInput', 'onKeyDown', 'onKeyPress', 'onKeyUp', 'onLoad', 'onWheel', 'onDragOver',
-  'onDragStart', 'onDrop', 'onMouseDown', 'onMouseEnter', 'onMouseLeave', 'onMouseMove', 'onMouseOut', 'onMouseOver',
-  'onMouseUp', 'onPaste', 'onScroll', 'onSelect', 'onSubmit', 'onToggle', 'onTransitionEnd', 'radioGroup', 'readOnly', 'referrerPolicy',
+  'maxLength', 'mediaGroup', 'minLength', 'noValidate', 'radioGroup', 'readOnly', 'referrerPolicy',
   'rowSpan', 'srcDoc', 'srcLang', 'srcSet', 'useMap',
   // SVG attributes
   // See https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute
@@ -289,27 +310,16 @@ const DOM_PROPERTY_NAMES_TWO_WORDS = [
   // React specific attributes https://reactjs.org/docs/dom-elements.html#differences-in-attributes
   'className', 'dangerouslySetInnerHTML', 'defaultValue', 'defaultChecked', 'htmlFor',
   // Events' capture events
-  'onBeforeInput', 'onChange',
-  'onInvalid', 'onReset', 'onTouchCancel', 'onTouchEnd', 'onTouchMove', 'onTouchStart', 'suppressContentEditableWarning', 'suppressHydrationWarning',
-  'onAbort', 'onCanPlay', 'onCanPlayThrough', 'onDurationChange', 'onEmptied', 'onEncrypted', 'onEnded',
-  'onLoadedData', 'onLoadedMetadata', 'onLoadStart', 'onPause', 'onPlay', 'onPlaying', 'onProgress', 'onRateChange',
-  'onSeeked', 'onSeeking', 'onStalled', 'onSuspend', 'onTimeUpdate', 'onVolumeChange', 'onWaiting',
-  'onCopyCapture', 'onCutCapture', 'onPasteCapture', 'onCompositionEndCapture', 'onCompositionStartCapture', 'onCompositionUpdateCapture',
-  'onFocusCapture', 'onBlurCapture', 'onChangeCapture', 'onBeforeInputCapture', 'onInputCapture', 'onResetCapture', 'onSubmitCapture',
-  'onInvalidCapture', 'onLoadCapture', 'onErrorCapture', 'onKeyDownCapture', 'onKeyPressCapture', 'onKeyUpCapture',
-  'onAbortCapture', 'onCanPlayCapture', 'onCanPlayThroughCapture', 'onDurationChangeCapture', 'onEmptiedCapture', 'onEncryptedCapture',
-  'onEndedCapture', 'onLoadedDataCapture', 'onLoadedMetadataCapture', 'onLoadStartCapture', 'onPauseCapture', 'onPlayCapture',
-  'onPlayingCapture', 'onProgressCapture', 'onRateChangeCapture', 'onSeekedCapture', 'onSeekingCapture', 'onStalledCapture', 'onSuspendCapture',
-  'onTimeUpdateCapture', 'onVolumeChangeCapture', 'onWaitingCapture', 'onSelectCapture', 'onTouchCancelCapture', 'onTouchEndCapture',
-  'onTouchMoveCapture', 'onTouchStartCapture', 'onScrollCapture', 'onWheelCapture', 'onAnimationEndCapture', 'onAnimationIteration',
-  'onAnimationStartCapture', 'onTransitionEndCapture',
-  'onAuxClick', 'onAuxClickCapture', 'onClickCapture', 'onContextMenuCapture', 'onDoubleClickCapture',
-  'onDragCapture', 'onDragEndCapture', 'onDragEnterCapture', 'onDragExitCapture', 'onDragLeaveCapture',
-  'onDragOverCapture', 'onDragStartCapture', 'onDropCapture', 'onMouseDown', 'onMouseDownCapture',
-  'onMouseMoveCapture', 'onMouseOutCapture', 'onMouseOverCapture', 'onMouseUpCapture',
+  'suppressContentEditableWarning', 'suppressHydrationWarning',
   // Video specific
   'autoPictureInPicture', 'controlsList', 'disablePictureInPicture', 'disableRemotePlayback',
 ];
+
+// Event handlers that should be able to be added to any HTML/DOM element, but not defined in React
+const GLOBAL_NATIVE_EVENT_HANDLERS = ['onCancel', 'onClose', 'onCueChange', 'onFormData',
+  /* Note: onresize only works on the window object, but is valid HTML on any element */ 'onResize',
+  'onScrollEnd', 'onSecurityPolicyViolation', 'onSlotChange', 'onToggle', 'onWebkitAnimationEnd',
+  'onWebkitAnimationIteration', 'onWebkitAnimationStart', 'onWebkitTransitionEnd'];
 
 const DOM_PROPERTIES_IGNORE_CASE = ['charset', 'allowFullScreen', 'webkitAllowFullScreen', 'mozAllowFullScreen', 'webkitDirectory'];
 
@@ -334,7 +344,6 @@ const REACT_ON_PROPS = [
   'onGotPointerCapture',
   'onGotPointerCaptureCapture',
   'onLostPointerCapture',
-  'onLostPointerCapture',
   'onLostPointerCaptureCapture',
   'onPointerCancel',
   'onPointerCancelCapture',
@@ -355,7 +364,8 @@ const REACT_ON_PROPS = [
 ];
 
 function getDOMPropertyNames(context) {
-  const ALL_DOM_PROPERTY_NAMES = DOM_PROPERTY_NAMES_TWO_WORDS.concat(DOM_PROPERTY_NAMES_ONE_WORD);
+  const ALL_DOM_PROPERTY_NAMES = DOM_PROPERTY_NAMES_TWO_WORDS.concat(DOM_PROPERTY_NAMES_ONE_WORD)
+    .concat(GLOBAL_NATIVE_EVENT_HANDLERS);
   // this was removed in React v16.1+, see https://github.com/facebook/react/pull/10823
   if (!testReactVersion(context, '>= 16.1.0')) {
     return ALL_DOM_PROPERTY_NAMES.concat('allowTransparency');
@@ -488,6 +498,7 @@ function getStandardName(name, context) {
 // ------------------------------------------------------------------------------
 
 const messages = {
+  invalidExclusivePropOnTag: 'Invalid property \'{{name}}\' found on tag \'{{tagName}}\', it is not allowed on {{disallowedTags}}',
   invalidPropOnTag: 'Invalid property \'{{name}}\' found on tag \'{{tagName}}\', but it is only allowed on: {{allowedTags}}',
   unknownPropWithStandardName: 'Unknown property \'{{name}}\' found, use \'{{standardName}}\' instead',
   unknownProp: 'Unknown property \'{{name}}\' found',
@@ -552,9 +563,25 @@ module.exports = {
 
         // Some attributes are allowed on some tags only
         const allowedTags = has(ATTRIBUTE_TAGS_MAP, name) ? ATTRIBUTE_TAGS_MAP[name] : null;
-        if (tagName && allowedTags) {
+        const disallowedTags = has(ATTRIBUTES_WITH_EXCLUSIONS, name) ? ATTRIBUTES_WITH_EXCLUSIONS[name] : null;
+        if (tagName && (allowedTags || disallowedTags)) {
           // Scenario 1A: Allowed attribute found where not supposed to, report it
-          if (allowedTags.indexOf(tagName) === -1) {
+          if (disallowedTags && disallowedTags.indexOf(tagName) !== -1) {
+            report(
+              context,
+              messages.invalidExclusivePropOnTag,
+              'invalidExclusivePropOnTag',
+              {
+                node,
+                data: {
+                  name: actualName,
+                  tagName,
+                  disallowedTags: disallowedTags.join(', '),
+                },
+              }
+            );
+          }
+          if (allowedTags && allowedTags.indexOf(tagName) === -1) {
             report(context, messages.invalidPropOnTag, 'invalidPropOnTag', {
               node,
               data: {

--- a/tests/lib/rules/no-unknown-property.js
+++ b/tests/lib/rules/no-unknown-property.js
@@ -61,14 +61,10 @@ ruleTester.run('no-unknown-property', rule, {
     { code: '<meta property="og:type" content="website" />' },
     { code: '<input type="checkbox" checked={checked} disabled={disabled} id={id} onChange={onChange} />' },
     { code: '<video playsInline />' },
-    { code: '<img onError={foo} onLoad={bar} />' },
+    { code: '<div onError={foo} onLoad={bar} />' },
     { code: '<picture inert={false} onError={foo} onLoad={bar} />' },
-    { code: '<iframe onError={foo} onLoad={bar} />' },
-    { code: '<script onLoad={bar} onError={foo} />' },
-    { code: '<source onError={foo} />' },
     { code: '<link onLoad={bar} onError={foo} />' },
     { code: '<link rel="preload" as="image" href="someHref" imageSrcSet="someImageSrcSet" imageSizes="someImageSizes" />' },
-    { code: '<object onLoad={bar} />' },
     { code: '<video allowFullScreen webkitAllowFullScreen mozAllowFullScreen />' },
     { code: '<iframe allowFullScreen webkitAllowFullScreen mozAllowFullScreen />' },
     { code: '<table border="1" />' },
@@ -406,59 +402,14 @@ ruleTester.run('no-unknown-property', rule, {
       ],
     },
     {
-      code: '<div onAbort={this.abort} onDurationChange={this.durationChange} onEmptied={this.emptied} onEnded={this.end} onError={this.error} />',
+      code: '<body onError={this.error} />',
       errors: [
         {
-          messageId: 'invalidPropOnTag',
-          data: {
-            name: 'onAbort',
-            tagName: 'div',
-            allowedTags: 'audio, video',
-          },
-        },
-        {
-          messageId: 'invalidPropOnTag',
-          data: {
-            name: 'onDurationChange',
-            tagName: 'div',
-            allowedTags: 'audio, video',
-          },
-        },
-        {
-          messageId: 'invalidPropOnTag',
-          data: {
-            name: 'onEmptied',
-            tagName: 'div',
-            allowedTags: 'audio, video',
-          },
-        },
-        {
-          messageId: 'invalidPropOnTag',
-          data: {
-            name: 'onEnded',
-            tagName: 'div',
-            allowedTags: 'audio, video',
-          },
-        },
-        {
-          messageId: 'invalidPropOnTag',
+          messageId: 'invalidExclusivePropOnTag',
           data: {
             name: 'onError',
-            tagName: 'div',
-            allowedTags: 'audio, video, img, link, source, script, picture, iframe',
-          },
-        },
-      ],
-    },
-    {
-      code: '<div onLoad={this.load} />',
-      errors: [
-        {
-          messageId: 'invalidPropOnTag',
-          data: {
-            name: 'onLoad',
-            tagName: 'div',
-            allowedTags: 'script, img, link, picture, iframe, object',
+            tagName: 'body',
+            disallowedTags: 'body, frameset',
           },
         },
       ],


### PR DESCRIPTION
Fixes #3505. 

Added some attributes that should be able to be used on any element, along with a way to exclude only specific elements for some properties (such as `onFocus` on a `<body>` element). 

For more info on these global events, see the "event handler" section in the [MDN documentation on global attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes), and the [HTML specification on global event handlers here](https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers-on-elements,-document-objects,-and-window-objects).