### PR TITLE
Update link to `eslint-plugin-jsx-a11y` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ module.exports = [
 ## Other useful plugins
 
 - Rules of Hooks: [eslint-plugin-react-hooks](https://github.com/facebook/react/tree/master/packages/eslint-plugin-react-hooks)
-- JSX accessibility: [eslint-plugin-jsx-a11y](https://github.com/evcohen/eslint-plugin-jsx-a11y)
+- JSX accessibility: [eslint-plugin-jsx-a11y](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y)
 - React Native: [eslint-plugin-react-native](https://github.com/Intellicode/eslint-plugin-react-native)
 
 ## License


### PR DESCRIPTION
Quick PR to update the link to `eslint-plugin-jsx-a11y` in the README.