### PR TITLE
[Fix] no-unknown-property `fill` for `marker`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 ### Fixed
 * configs: restore `parserOptions` in legacy configs ([#3523][] @ljharb)
 * [`jsx-no-constructed-context-values`], [`jsx-no-useless-fragment`]: add a rule schema (@ljharb)
+( [`no-unknown-property`]: add `fill` for `<marker>` ([#3525][] @alexey-koran)
 
+[#3525]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3525
 [#3520]: https://github.com/jsx-eslint/eslint-plugin-react/issues/3523
 
 ## [7.32.1] - 2023.01.16

--- a/lib/rules/no-unknown-property.js
+++ b/lib/rules/no-unknown-property.js
@@ -42,6 +42,7 @@ const ATTRIBUTE_TAGS_MAP = {
     'ellipse',
     'g',
     'line',
+    'marker',
     'mask',
     'path',
     'polygon',

--- a/tests/lib/rules/no-unknown-property.js
+++ b/tests/lib/rules/no-unknown-property.js
@@ -131,6 +131,7 @@ ruleTester.run('no-unknown-property', rule, {
     { code: '<view id="one" viewBox="0 0 100 100" />' },
     { code: '<hr align="top" />' },
     { code: '<applet align="top" />' },
+    { code: '<marker fill="#000" />' },
     { code: '<dialog onClose={handler} open id="dialog" returnValue="something" onCancel={handler2} />' },
     {
       code: `
@@ -471,7 +472,7 @@ ruleTester.run('no-unknown-property', rule, {
           data: {
             name: 'fill',
             tagName: 'div',
-            allowedTags: 'altGlyph, circle, ellipse, g, line, mask, path, polygon, polyline, rect, svg, text, textPath, tref, tspan, use, animate, animateColor, animateMotion, animateTransform, set',
+            allowedTags: 'altGlyph, circle, ellipse, g, line, marker, mask, path, polygon, polyline, rect, svg, text, textPath, tref, tspan, use, animate, animateColor, animateMotion, animateTransform, set',
           },
         },
       ],


### PR DESCRIPTION
Similar to https://github.com/jsx-eslint/eslint-plugin-react/issues/3416 but for fill of marker

https://developer.mozilla.org/en-US/docs/Web/SVG/Element/marker

```jsx
error  Invalid property 'fill' found on tag 'marker', but it is only allowed on: altGlyph, circle, ellipse, g, line, mask, path, polygon, polyline, rect, svg, text, textPath, tref, tspan, use, animate, animateColor, animateMotion, animateTransform, set  react/no-unknown-property

<marker fill='#000' />
```