### PR TITLE
[New] `checkContextObjects` option in `display-name`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,14 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 
 ## Unreleased
 
+### Added
+* [`display-name`]: add `checkContextObjects` option ([#3529][] @JulesBlm)
+
 ### Fixed
 * [`no-array-index-key`]: consider flatMap ([#3530][] @k-yle)
 
 [#3530]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3530
+[#3529]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3529
 
 ## [7.32.2] - 2023.01.28
 

--- a/docs/rules/display-name.md
+++ b/docs/rules/display-name.md
@@ -45,7 +45,7 @@ const Hello = React.memo(function Hello({ a }) {
 
 ```js
 ...
-"react/display-name": [<enabled>, { "ignoreTranspilerName": <boolean> }]
+"react/display-name": [<enabled>, { "ignoreTranspilerName": <boolean>, "checkContextObjects": <boolean> }]
 ...
 ```
 
@@ -126,6 +126,33 @@ function HelloComponent() {
   });
 }
 module.exports = HelloComponent();
+```
+
+### checkContextObjects (default: `false`)
+
+`displayName` allows you to [name your context](https://reactjs.org/docs/context.html#contextdisplayname) object. This name is used in the React dev tools for the context's `Provider` and `Consumer`.
+When `true` this rule will warn on context objects without a `displayName`.
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+const Hello = React.createContext();
+```
+
+```jsx
+const Hello = createContext();
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+const Hello = React.createContext();
+Hello.displayName = "HelloContext";
+```
+
+```jsx
+const Hello = createContext();
+Hello.displayName = "HelloContext";
 ```
 
 ## About component detection

--- a/lib/rules/display-name.js
+++ b/lib/rules/display-name.js
@@ -8,6 +8,7 @@
 const values = require('object.values');
 
 const Components = require('../util/Components');
+const isCreateContext = require('../util/isCreateContext');
 const astUtil = require('../util/ast');
 const componentUtil = require('../util/componentUtil');
 const docsUrl = require('../util/docsUrl');
@@ -21,6 +22,7 @@ const report = require('../util/report');
 
 const messages = {
   noDisplayName: 'Component definition is missing display name',
+  noContextDisplayName: 'Context definition is missing display name',
 };
 
 module.exports = {
@@ -40,6 +42,9 @@ module.exports = {
         ignoreTranspilerName: {
           type: 'boolean',
         },
+        checkContextObjects: {
+          type: 'boolean',
+        },
       },
       additionalProperties: false,
     }],
@@ -48,6 +53,9 @@ module.exports = {
   create: Components.detect((context, components, utils) => {
     const config = context.options[0] || {};
     const ignoreTranspilerName = config.ignoreTranspilerName || false;
+    const checkContextObjects = (config.checkContextObjects || false) && testReactVersion(context, '>= 16.3.0');
+
+    const contextObjects = new Map();
 
     /**
      * Mark a prop type as declared
@@ -84,6 +92,16 @@ module.exports = {
 
       report(context, messages.noDisplayName, 'noDisplayName', {
         node: component.node,
+      });
+    }
+
+    /**
+     * Reports missing display name for a given context object
+     * @param {Object} contextObj The context object to process
+     */
+    function reportMissingContextDisplayName(contextObj) {
+      report(context, messages.noContextDisplayName, 'noContextDisplayName', {
+        node: contextObj.node,
       });
     }
 
@@ -144,6 +162,16 @@ module.exports = {
     // --------------------------------------------------------------------------
 
     return {
+      ExpressionStatement(node) {
+        if (checkContextObjects && isCreateContext(node)) {
+          contextObjects.set(node.expression.left.name, { node, hasDisplayName: false });
+        }
+      },
+      VariableDeclarator(node) {
+        if (checkContextObjects && isCreateContext(node)) {
+          contextObjects.set(node.id.name, { node, hasDisplayName: false });
+        }
+      },
       'ClassProperty, PropertyDefinition'(node) {
         if (!propsUtil.isDisplayNameDeclaration(node)) {
           return;
@@ -154,6 +182,14 @@ module.exports = {
       MemberExpression(node) {
         if (!propsUtil.isDisplayNameDeclaration(node.property)) {
           return;
+        }
+        if (
+          checkContextObjects
+          && node.object
+          && node.object.name
+          && contextObjects.has(node.object.name)
+        ) {
+          contextObjects.get(node.object.name).hasDisplayName = true;
         }
         const component = utils.getRelatedComponent(node);
         if (!component) {
@@ -258,6 +294,11 @@ module.exports = {
         values(list).filter((component) => !component.hasDisplayName).forEach((component) => {
           reportMissingDisplayName(component);
         });
+        if (checkContextObjects) {
+          // Report missing display name for all context objects
+          const contextsList = Array.from(contextObjects.values()).filter((v) => !v.hasDisplayName);
+          contextsList.forEach((contextObj) => reportMissingContextDisplayName(contextObj));
+        }
       },
     };
   }),

--- a/lib/util/isCreateContext.js
+++ b/lib/util/isCreateContext.js
@@ -1,0 +1,53 @@
+'use strict';
+
+/**
+ * Checks if the node is a React.createContext call
+ * @param {ASTNode} node - The AST node being checked.
+ * @returns {Boolean} - True if node is a React.createContext call, false if not.
+ */
+module.exports = function isCreateContext(node) {
+  if (
+    node.init
+    && node.init.type === 'CallExpression'
+    && node.init.callee
+    && node.init.callee.name === 'createContext'
+  ) {
+    return true;
+  }
+
+  if (
+    node.init
+    && node.init.callee
+    && node.init.callee.type === 'MemberExpression'
+    && node.init.callee.property
+    && node.init.callee.property.name === 'createContext'
+  ) {
+    return true;
+  }
+
+  if (
+    node.expression
+    && node.expression.type === 'AssignmentExpression'
+    && node.expression.operator === '='
+    && node.expression.right.type === 'CallExpression'
+    && node.expression.right.callee
+    && node.expression.right.callee.name === 'createContext'
+  ) {
+    return true;
+  }
+
+  if (
+    node.expression
+    && node.expression.type === 'AssignmentExpression'
+    && node.expression.operator === '='
+    && node.expression.right.type === 'CallExpression'
+    && node.expression.right.callee
+    && node.expression.right.callee.type === 'MemberExpression'
+    && node.expression.right.callee.property
+    && node.expression.right.callee.property.name === 'createContext'
+  ) {
+    return true;
+  }
+
+  return false;
+};

--- a/tests/lib/rules/display-name.js
+++ b/tests/lib/rules/display-name.js
@@ -755,6 +755,129 @@ ruleTester.run('display-name', rule, {
         },
       },
     },
+    {
+      code: `
+        import React from 'react';
+
+        const Hello = React.createContext();
+        Hello.displayName = "HelloContext"
+      `,
+      options: [{ checkContextObjects: true }],
+    },
+    {
+      code: `
+        import { createContext } from 'react';
+
+        const Hello = createContext();
+        Hello.displayName = "HelloContext"
+      `,
+      options: [{ checkContextObjects: true }],
+    },
+    {
+      code: `
+        import { createContext } from 'react';
+
+        const Hello = createContext();
+
+        const obj = {};
+        obj.displayName = "False positive";
+
+        Hello.displayName = "HelloContext"
+      `,
+      options: [{ checkContextObjects: true }],
+    },
+    {
+      code: `
+        import * as React from 'react';
+
+        const Hello = React.createContext();
+
+        const obj = {};
+        obj.displayName = "False positive";
+
+        Hello.displayName = "HelloContext";
+      `,
+      options: [{ checkContextObjects: true }],
+    },
+    {
+      code: `
+        const obj = {};
+        obj.displayName = "False positive";
+      `,
+      options: [{ checkContextObjects: true }],
+    },
+    // React.createContext should be accepted in React versions in the following range:
+    // >= 16.13.0
+    {
+      code: `
+        import { createContext } from 'react';
+
+        const Hello = createContext();
+      `,
+      settings: {
+        react: {
+          version: '16.2.0',
+        },
+      },
+      options: [{ checkContextObjects: true }],
+    },
+    {
+      code: `
+        import { createContext } from 'react';
+
+        const Hello = createContext();
+        Hello.displayName = "HelloContext";
+      `,
+      settings: {
+        react: {
+          version: '>16.3.0',
+        },
+      },
+      options: [{ checkContextObjects: true }],
+    },
+    {
+      code: `
+        import { createContext } from 'react';
+
+        let Hello;
+        Hello = createContext();
+        Hello.displayName = "HelloContext";
+      `,
+      options: [{ checkContextObjects: true }],
+    },
+    {
+      code: `
+        import { createContext } from 'react';
+
+        const Hello = createContext();
+      `,
+      settings: {
+        react: {
+          version: '>16.3.0',
+        },
+      },
+      options: [{ checkContextObjects: false }],
+    },
+    {
+      code: `
+        import { createContext } from 'react';
+
+        var Hello;
+        Hello = createContext();
+        Hello.displayName = "HelloContext";
+      `,
+      options: [{ checkContextObjects: true }],
+    },
+    {
+      code: `
+        import { createContext } from 'react';
+
+        var Hello;
+        Hello = React.createContext();
+        Hello.displayName = "HelloContext";
+      `,
+      options: [{ checkContextObjects: true }],
+    },
   ]),
 
   invalid: parsers.all([
@@ -1179,6 +1302,78 @@ ruleTester.run('display-name', rule, {
           line: 9,
         },
       ],
+    },
+    {
+      code: `
+        import React from 'react';
+
+        const Hello = React.createContext();
+      `,
+      errors: [
+        {
+          messageId: 'noContextDisplayName',
+          line: 4,
+        },
+      ],
+      options: [{ checkContextObjects: true }],
+    },
+    {
+      code: `
+        import * as React from 'react';
+
+        const Hello = React.createContext();
+      `,
+      errors: [
+        {
+          messageId: 'noContextDisplayName',
+          line: 4,
+        },
+      ],
+      options: [{ checkContextObjects: true }],
+    },
+    {
+      code: `
+        import { createContext } from 'react';
+
+        const Hello = createContext();
+      `,
+      errors: [
+        {
+          messageId: 'noContextDisplayName',
+          line: 4,
+        },
+      ],
+      options: [{ checkContextObjects: true }],
+    },
+    {
+      code: `
+        import { createContext } from 'react';
+
+        var Hello;
+        Hello = createContext();
+      `,
+      errors: [
+        {
+          messageId: 'noContextDisplayName',
+          line: 5,
+        },
+      ],
+      options: [{ checkContextObjects: true }],
+    },
+    {
+      code: `
+        import { createContext } from 'react';
+
+        var Hello;
+        Hello = React.createContext();
+      `,
+      errors: [
+        {
+          messageId: 'noContextDisplayName',
+          line: 5,
+        },
+      ],
+      options: [{ checkContextObjects: true }],
     },
   ]),
 });


### PR DESCRIPTION
I'm proposing adding a new rule that checks if the `displayName` property is set for context objects, see [`Context.displayName`](https://reactjs.org/docs/context.html#contextdisplayname) in the React docs.

With multiple Context providers in an app, consistently setting a `displayName` makes it easy to see which is which in the React dev tools.

Some things to consider

* Should it perhaps be part of the `display-name` rule instead of a separate rule?
* Does it need more tests?
* Does this checking approach make sense? (This is my first time writing an ESLint rule, so I wouldn't be surprised if this is not the best way)
* Does it need to check more cases?
