### PR TITLE
consider flatMap for no-array-index-key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 
 ## Unreleased
 
+### Fixed
+* [`no-array-index-key`]: consider flatMap ([#3530][] @k-yle)
+
+[#3530]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3530
+
 ## [7.32.2] - 2023.01.28
 
 ### Fixed

--- a/docs/rules/no-array-index-key.md
+++ b/docs/rules/no-array-index-key.md
@@ -45,6 +45,10 @@ things.findIndex((thing, index) => {
   otherThings.push(<Hello key={index} />);
 });
 
+things.flatMap((thing, index) => (
+  <Hello key={index} />
+));
+
 things.reduce((collection, thing, index) => (
   collection.concat(<Hello key={index} />)
 ), []);

--- a/lib/rules/no-array-index-key.js
+++ b/lib/rules/no-array-index-key.js
@@ -65,6 +65,7 @@ module.exports = {
       filter: 1,
       find: 1,
       findIndex: 1,
+      flatMap: 1,
       forEach: 1,
       map: 1,
       reduce: 2,

--- a/tests/lib/rules/no-array-index-key.js
+++ b/tests/lib/rules/no-array-index-key.js
@@ -94,6 +94,9 @@ ruleTester.run('no-array-index-key', rule, {
       code: 'foo.map((bar, i) => <Foo key={String(baz)} />)',
     },
     {
+      code: 'foo.flatMap((a) => <Foo key={a} />)',
+    },
+    {
       code: 'foo.reduce((a, b) => a.concat(<Foo key={b.id} />), [])',
     },
     {
@@ -224,6 +227,10 @@ ruleTester.run('no-array-index-key', rule, {
     },
     {
       code: 'foo.reduce((a, b, i) => a.concat(<Foo key={i} />), [])',
+      errors: [{ messageId: 'noArrayIndex' }],
+    },
+    {
+      code: 'foo.flatMap((a, i) => <Foo key={i} />)',
       errors: [{ messageId: 'noArrayIndex' }],
     },
     {


### PR DESCRIPTION
The rule currently considers `.map()` but not `.flatMap()`
