### PR TITLE
Fixes #3482 - handle formatMessage calls

### DIFF
--- a/docs/rules/no-unstable-nested-components.md
+++ b/docs/rules/no-unstable-nested-components.md
@@ -124,6 +124,7 @@ function Component() {
   "off" | "warn" | "error",
   {
     "allowAsProps": true | false,
+    "ignoreFunctions': [] /* Ignore components found in these functions. Useful for intl.formatMessage */,
     "customValidators": [] /* optional array of validators used for propTypes validation */
   }
 ]

--- a/lib/rules/no-unstable-nested-components.js
+++ b/lib/rules/no-unstable-nested-components.js
@@ -322,7 +322,10 @@ module.exports = {
 
   create: Components.detect((context, components, utils) => {
     const allowAsProps = context.options.some((option) => option && option.allowAsProps);
-    const ignoreFunctions = context.options.some((option) => option && option.ignoreFunctions);
+    const ignoreFunctions = context.options.reduce(
+      (ignore, option) => ignore.concat(option && option.ignoreFunctions),
+      []
+    );
 
     /**
      * Check whether given node is declared inside class component's render block

--- a/lib/rules/no-unstable-nested-components.js
+++ b/lib/rules/no-unstable-nested-components.js
@@ -144,31 +144,6 @@ function isMapCall(node) {
 }
 
 /**
- * Check whether given node is part of a formatMessage call
- * ```jsx
- * {intl.formatMessage(messages.testMessage, {
- * a: (...chunks) => <a href="/">{chunks}</a>
- * })}
- * ```
- * @param {ASTNode} node The AST node
- * @returns {Boolean} True if node is directly inside `map` call, false if not
- */
-function isFormatMessageCall(node) {
-  return (
-    node
-    && node.parent
-    && node.parent.type === 'Property'
-    && node.parent.parent
-    && node.parent.parent.type === 'ObjectExpression'
-    && node.parent.parent.parent
-    && node.parent.parent.parent.type === 'CallExpression'
-    && node.parent.parent.parent.callee
-    && node.parent.parent.parent.callee.property
-    && node.parent.parent.parent.callee.property.name === 'formatMessage'
-  );
-}
-
-/**
  * Check whether given node is `ReturnStatement` of a React hook
  * @param {ASTNode} node The AST node
  * @param {Context} context eslint context
@@ -189,6 +164,30 @@ function isReturnStatementOfHook(node, context) {
     && callExpression.callee
     && HOOK_REGEXP.test(callExpression.callee.name)
   );
+}
+
+/**
+ * Check whether given node is declared inside a specific function.
+ *
+ * ```jsx
+ * {intl.formatMessage(messages.testMessage, {
+ *   a: (...chunks) => <a href="/">{chunks}</a>
+ *   // ^ This returns JSX, so technically it's a component
+ * })}
+ * ```
+ * @param {ASTNode} node The AST node
+ * @param {Context} context eslint context
+ * @param {Array<string>} ignoredFunctions
+ * @returns {Boolean} True if component is declared inside a render prop, false if not
+ */
+function isDescendantOfIgnoredFunction(node, context, ignoredFunctions) {
+  const code = context.getSourceCode();
+  return context.getAncestors().some((n) => ignoredFunctions.some((functionName) => {
+    if (n.type === 'CallExpression') {
+      return code.getText(n.callee) === functionName;
+    }
+    return false;
+  }));
 }
 
 /**
@@ -310,6 +309,12 @@ module.exports = {
         allowAsProps: {
           type: 'boolean',
         },
+        ignoreFunctions: {
+          type: 'array',
+          items: {
+            type: 'string',
+          },
+        },
       },
       additionalProperties: false,
     }],
@@ -317,6 +322,7 @@ module.exports = {
 
   create: Components.detect((context, components, utils) => {
     const allowAsProps = context.options.some((option) => option && option.allowAsProps);
+    const ignoreFunctions = context.options.some((option) => option && option.ignoreFunctions);
 
     /**
      * Check whether given node is declared inside class component's render block
@@ -456,7 +462,6 @@ module.exports = {
         // Prevent reporting components created inside Array.map calls
         || isMapCall(node)
         || isMapCall(node.parent)
-        || isFormatMessageCall(node)
 
         // Do not mark components declared inside hooks (or falsy '() => null' clean-up methods)
         || isReturnStatementOfHook(node, context)
@@ -469,6 +474,9 @@ module.exports = {
 
         // Prevent falsely reporting detected "components" which do not return JSX
         || isStatelessComponentReturningNull(node)
+        || (ignoreFunctions
+            && ignoreFunctions.length > 0
+            && isDescendantOfIgnoredFunction(node, context, ignoreFunctions))
       ) {
         return;
       }

--- a/lib/rules/no-unstable-nested-components.js
+++ b/lib/rules/no-unstable-nested-components.js
@@ -144,6 +144,31 @@ function isMapCall(node) {
 }
 
 /**
+ * Check whether given node is part of a formatMessage call
+ * ```jsx
+ * {intl.formatMessage(messages.testMessage, {
+ * a: (...chunks) => <a href="/">{chunks}</a>
+ * })}
+ * ```
+ * @param {ASTNode} node The AST node
+ * @returns {Boolean} True if node is directly inside `map` call, false if not
+ */
+function isFormatMessageCall(node) {
+  return (
+    node
+    && node.parent
+    && node.parent.type === 'Property'
+    && node.parent.parent
+    && node.parent.parent.type === 'ObjectExpression'
+    && node.parent.parent.parent
+    && node.parent.parent.parent.type === 'CallExpression'
+    && node.parent.parent.parent.callee
+    && node.parent.parent.parent.callee.property
+    && node.parent.parent.parent.callee.property.name === 'formatMessage'
+  );
+}
+
+/**
  * Check whether given node is `ReturnStatement` of a React hook
  * @param {ASTNode} node The AST node
  * @param {Context} context eslint context
@@ -431,6 +456,7 @@ module.exports = {
         // Prevent reporting components created inside Array.map calls
         || isMapCall(node)
         || isMapCall(node.parent)
+        || isFormatMessageCall(node)
 
         // Do not mark components declared inside hooks (or falsy '() => null' clean-up methods)
         || isReturnStatementOfHook(node, context)

--- a/tests/lib/rules/no-unstable-nested-components.js
+++ b/tests/lib/rules/no-unstable-nested-components.js
@@ -230,6 +230,29 @@ ruleTester.run('no-unstable-nested-components', rule, {
     },
     {
       code: `
+        const messages = defineMessages({
+          testMessage: {
+            id: 'test-message',
+            defaultMessage: '<a>link</a>',
+            description: 'Message used to verify the no-unstable-nested-components rule'
+          }
+        })
+        function ParentComponent() {
+          const intl = useIntl()
+
+
+          return (
+            <SomeComponent>
+              {intl.formatMessage(messages.testMessage, {
+                a: (...chunks) => <a href="/">{chunks}</a>
+              })}
+            </SomeComponent>
+          )
+        }
+      `,
+    },
+    {
+      code: `
         function ParentComponent() {
           return (
             <ComplexRenderPropComponent

--- a/tests/lib/rules/no-unstable-nested-components.js
+++ b/tests/lib/rules/no-unstable-nested-components.js
@@ -250,6 +250,9 @@ ruleTester.run('no-unstable-nested-components', rule, {
           )
         }
       `,
+      options: [{
+        ignoreFunctions: ['intl.formatMessage'],
+      }],
     },
     {
       code: `


### PR DESCRIPTION
I handled this similar to `isMap` because `formatMessage` seems like a similar special case. https://formatjs.io/docs/intl#formatmessage

When defining a message to be translated, `defaultMessage` can contain placeholders like `{name}`, but it also uses an HTML-like format: `<a>link text</a>`. Notice there's no href, because it gets replaced using a function that returns JSX that fills in the details. 

```
intl.formatMessage(messages.example, {
  name: 'Asa'
  a: (...chunks) => <a href="/">{...chunks}</a>
})
```


> I'm a bit confused. `Trigger` here is definitely a component, and should be warned on - but `b` isn't a component, because it's got a lowercase name (if it was `B` i'd say it _is_ a component).
https://github.com/jsx-eslint/eslint-plugin-react/issues/3482#issuecomment-1304406131

This plugin seems to define components as any function that returns JSX. By that definition, this IS a component even if it happens to be assigned to a property of an object. Components can either start with a capital letter or be part of an object, so in this example `formatMessage` could internally call `<values.a>link text</values.a>` and use it directly as a component.


