### PR TITLE
Add `disallowedFor` to `forbid-component-props` and `allowedFor` to `forbid-dom-props`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 * [`display-name`]: add `checkContextObjects` option ([#3529][] @JulesBlm)
 * [`jsx-first-prop-new-line`]: add `multiprop` option ([#3533][] @haydncomley)
 * [`no-deprecated`]: add React 18 deprecations ([#3548][] @sergei-startsev)
+* [`forbid-component-props`]: add `disallowedFor` option ([#3417][] @jacketwpbb)
 
 ### Fixed
 * [`no-array-index-key`]: consider flatMap ([#3530][] @k-yle)
@@ -26,6 +27,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 [#3533]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3533
 [#3530]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3530
 [#3529]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3529
+[#3417]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3417
 
 ## [7.32.2] - 2023.01.28
 

--- a/docs/rules/forbid-component-props.md
+++ b/docs/rules/forbid-component-props.md
@@ -50,8 +50,18 @@ custom message, and a component allowlist:
 ```js
 {
   "propName": "someProp",
-  "allowedFor": [SomeComponent, AnotherComponent],
-  "message": "Avoid using someProp"
+  "allowedFor": ["SomeComponent", "AnotherComponent"],
+  "message": "Avoid using someProp except SomeComponent and AnotherComponent"
+}
+```
+
+Use `disallowedFor` as an exclusion list to warn on props for specific components. `disallowedFor` must have at least one item.
+
+```js
+{
+  "propName": "someProp",
+  "disallowedFor": ["SomeComponent", "AnotherComponent"],
+  "message": "Avoid using someProp for SomeComponent and AnotherComponent"
 }
 ```
 

--- a/lib/rules/forbid-component-props.js
+++ b/lib/rules/forbid-component-props.js
@@ -39,26 +39,21 @@ module.exports = {
         forbid: {
           type: 'array',
           items: {
-            anyOf: [{
-              type: 'string',
-            }, {
-              type: 'object',
-              properties: {
-                propName: {
-                  type: 'string',
-                },
-                allowedFor: {
-                  type: 'array',
-                  uniqueItems: true,
-                  items: {
-                    type: 'string',
+            anyOf: [
+              { type: 'string' },
+              {
+                type: 'object',
+                properties: {
+                  propName: { type: 'string' },
+                  allowedFor: {
+                    type: 'array',
+                    uniqueItems: true,
+                    items: { type: 'string' },
                   },
-                },
-                message: {
-                  type: 'string',
+                  message: { type: 'string' },
                 },
               },
-            }],
+            ],
           },
         },
       },

--- a/lib/rules/forbid-component-props.js
+++ b/lib/rules/forbid-component-props.js
@@ -52,6 +52,22 @@ module.exports = {
                   },
                   message: { type: 'string' },
                 },
+                additionalProperties: false,
+              },
+              {
+                type: 'object',
+                properties: {
+                  propName: { type: 'string' },
+                  disallowedFor: {
+                    type: 'array',
+                    uniqueItems: true,
+                    minItems: 1,
+                    items: { type: 'string' },
+                  },
+                  message: { type: 'string' },
+                },
+                required: ['disallowedFor'],
+                additionalProperties: false,
               },
             ],
           },
@@ -66,6 +82,7 @@ module.exports = {
       const propName = typeof value === 'string' ? value : value.propName;
       const options = {
         allowList: typeof value === 'string' ? [] : (value.allowedFor || []),
+        disallowList: typeof value === 'string' ? [] : (value.disallowedFor || []),
         message: typeof value === 'string' ? null : value.message,
       };
       return [propName, options];
@@ -73,9 +90,17 @@ module.exports = {
 
     function isForbidden(prop, tagName) {
       const options = forbid.get(prop);
-      const allowList = options ? options.allowList : undefined;
+      if (!options) {
+        return false;
+      }
+
+      // disallowList should have a least one item (schema configuration)
+      const isTagForbidden = options.disallowList.length > 0
+        ? options.disallowList.indexOf(tagName) !== -1
+        : options.allowList.indexOf(tagName) === -1;
+
       // if the tagName is undefined (`<this.something>`), we assume it's a forbidden element
-      return typeof allowList !== 'undefined' && (typeof tagName === 'undefined' || allowList.indexOf(tagName) === -1);
+      return typeof tagName === 'undefined' || isTagForbidden;
     }
 
     return {

--- a/tests/lib/rules/forbid-component-props.js
+++ b/tests/lib/rules/forbid-component-props.js
@@ -153,9 +153,100 @@ ruleTester.run('forbid-component-props', rule, {
     },
     {
       code: `
+        const item = (<Foo className="foo" />);
+      `,
+      options: [
+        {
+          forbid: [
+            {
+              propName: 'className',
+              disallowedFor: ['ReactModal'],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+        const item = (<Foo className="foo" />);
+      `,
+      options: [
+        {
+          forbid: [
+            {
+              propName: 'className',
+              disallowedFor: ['ReactModal'],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
         <fbt:param name="Total number of files" number={true} />
       `,
       features: ['jsx namespace'],
+    },
+    {
+      code: `
+        const item = (
+          <Foo className="bar">
+            <ReactModal style={{color: "red"}} />
+          </Foo>
+        );
+      `,
+      options: [
+        {
+          forbid: [
+            {
+              propName: 'className',
+              disallowedFor: ['OtherModal', 'ReactModal'],
+            },
+            {
+              propName: 'style',
+              disallowedFor: ['Foo'],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+        const item = (
+          <Foo className="bar">
+            <ReactModal style={{color: "red"}} />
+          </Foo>
+        );
+      `,
+      options: [
+        {
+          forbid: [
+            {
+              propName: 'className',
+              disallowedFor: ['OtherModal', 'ReactModal'],
+            },
+            {
+              propName: 'style',
+              allowedFor: ['ReactModal'],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+        const item = (<this.ReactModal className="foo" />);
+      `,
+      options: [
+        {
+          forbid: [
+            {
+              propName: 'className',
+              disallowedFor: ['ReactModal'],
+            },
+          ],
+        },
+      ],
     },
   ]),
 
@@ -237,6 +328,34 @@ ruleTester.run('forbid-component-props', rule, {
     },
     {
       code: `
+        var First = createReactClass({
+          propTypes: externalPropTypes,
+          render: function() {
+            return <Foo style={{color: "red"}} />;
+          }
+        });
+      `,
+      options: [
+        {
+          forbid: [
+            {
+              propName: 'style',
+              disallowedFor: ['Foo'],
+            },
+          ],
+        },
+      ],
+      errors: [
+        {
+          messageId: 'propIsForbidden',
+          data: { prop: 'style' },
+          line: 5,
+          type: 'JSXAttribute',
+        },
+      ],
+    },
+    {
+      code: `
         const item = (<Foo className="foo" />);
       `,
       options: [
@@ -278,6 +397,78 @@ ruleTester.run('forbid-component-props', rule, {
           data: { prop: 'className' },
           line: 2,
           column: 40,
+          type: 'JSXAttribute',
+        },
+      ],
+    },
+    {
+      code: `
+        const item = (<this.ReactModal className="foo" />);
+      `,
+      options: [
+        {
+          forbid: [
+            {
+              propName: 'className',
+              disallowedFor: ['this.ReactModal'],
+            },
+          ],
+        },
+      ],
+      errors: [
+        {
+          messageId: 'propIsForbidden',
+          data: { prop: 'className' },
+          line: 2,
+          column: 40,
+          type: 'JSXAttribute',
+        },
+      ],
+    },
+    {
+      code: `
+        const item = (<ReactModal className="foo" />);
+      `,
+      options: [
+        {
+          forbid: [
+            {
+              propName: 'className',
+              disallowedFor: ['ReactModal'],
+            },
+          ],
+        },
+      ],
+      errors: [
+        {
+          messageId: 'propIsForbidden',
+          data: { prop: 'className' },
+          line: 2,
+          column: 35,
+          type: 'JSXAttribute',
+        },
+      ],
+    },
+    {
+      code: `
+        const item = (<AntdLayout.Content className="antdFoo" />);
+      `,
+      options: [
+        {
+          forbid: [
+            {
+              propName: 'className',
+              disallowedFor: ['AntdLayout.Content'],
+            },
+          ],
+        },
+      ],
+      errors: [
+        {
+          messageId: 'propIsForbidden',
+          data: { prop: 'className' },
+          line: 2,
+          column: 43,
           type: 'JSXAttribute',
         },
       ],


### PR DESCRIPTION
My use case is component props: I am using a component system (Antd) and want to disallow the `required` parameter on `Form.Item` to avoid confusion with a `require` parameter in HOCs that we create.

I found #3422 already existing, so this is a PR to solve that, as well as adding `allowList` to `forbid-dom-props` for symmetry.

I haven't yet figured out what the best way is to raise configuration issues, right now I'm just throwing an error, let me know if there's a better way!

(Motivation details: in Antd `require` only controls styling, and doesn't actually validate, in our HOCs I want it to validate, but don't want that confusion to bleed over into using `require` in the base (non-HOC) `Form.Item`s)