### PR TITLE
[Docs] Fix code syntax highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,11 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 * [`display-name`], [`prop-types`]: when checking for a capitalized name, ignore underscores entirely ([#3560][] @ljharb)
 * [`no-unused-state`]: avoid crashing on a class field function with destructured state ([#3568][] @ljharb)
 
+### Changed
+* [Docs] [`jsx-newline`], [`no-unsafe`], [`static-property-placement`]: Fix code syntax highlighting ([#3563][] @nbsp1221)
+
 [#3568]: https://github.com/jsx-eslint/eslint-plugin-react/issues/3568
+[#3563]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3563
 [#3560]: https://github.com/jsx-eslint/eslint-plugin-react/issues/3560
 [#3555]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3555
 [#3548]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3548

--- a/docs/rules/jsx-newline.md
+++ b/docs/rules/jsx-newline.md
@@ -10,7 +10,7 @@ This is a stylistic rule intended to make JSX code more readable by requiring or
 
 ## Rule Options
 
-```json
+```json5
 ...
 "react/jsx-newline": [<enabled>, { "prevent": <boolean>, "allowMultilines": <boolean> }]
 ...

--- a/docs/rules/no-unsafe.md
+++ b/docs/rules/no-unsafe.md
@@ -56,7 +56,7 @@ const Foo = bar({
 
 ## Rule Options
 
-```json
+```json5
 ...
 "react/no-unsafe": [<enabled>, { "checkAliases": <boolean> }]
 ...

--- a/docs/rules/static-property-placement.md
+++ b/docs/rules/static-property-placement.md
@@ -127,7 +127,7 @@ MyComponent.propTypes = { /*...*/ };
 
 ## Rule Options
 
-```json
+```json5
 ...
 "react/static-property-placement": [<enabled>]  // `static public field` enabled
 ...
@@ -135,7 +135,7 @@ MyComponent.propTypes = { /*...*/ };
 
 or alternatively:
 
-```json
+```json5
 ...
 "react/static-property-placement": [<enabled>, <string>]
 ...
@@ -143,7 +143,7 @@ or alternatively:
 
 or alternatively:
 
-```json
+```json5
 ...
 "react/static-property-placement": [<enabled>, <string>, {
   childContextTypes: <string>,
@@ -168,7 +168,7 @@ The `options` schema defined above allows you to specify different rules for the
 
 _This is only an example, we do not recommend this as a configuration._
 
-```json
+```json5
 ...
 "react/static-property-placement": ["warn", "property assignment", {
   childContextTypes: "static getter",


### PR DESCRIPTION
I fixed the issue with code syntax highlighting that caused a red background line to appear.

Before
![image](https://user-images.githubusercontent.com/50603255/233796903-e3c1d53f-b037-4439-800f-b817a467c605.png)

After
![image](https://user-images.githubusercontent.com/50603255/233796923-58f259ee-fb4d-4b99-93d9-423b1b830260.png)
