### PR TITLE
[Fix] `no-unused-prop-types`: returns no errors when using the spread operator in JSX element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,12 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 * [`no-unknown-property`]: allow `fill` prop on `<symbol>` ([#3555][] @stefanprobst)
 * [`display-name`], [`prop-types`]: when checking for a capitalized name, ignore underscores entirely ([#3560][] @ljharb)
 * [`no-unused-state`]: avoid crashing on a class field function with destructured state ([#3568][] @ljharb)
+* [`no-unused-prop-types`]: allow using spread with object expression in jsx ([#3570][] @akulsr0)
 
 ### Changed
 * [Docs] [`jsx-newline`], [`no-unsafe`], [`static-property-placement`]: Fix code syntax highlighting ([#3563][] @nbsp1221)
 
+[#3570]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3570
 [#3568]: https://github.com/jsx-eslint/eslint-plugin-react/issues/3568
 [#3563]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3563
 [#3560]: https://github.com/jsx-eslint/eslint-plugin-react/issues/3560

--- a/lib/util/usedPropTypes.js
+++ b/lib/util/usedPropTypes.js
@@ -534,7 +534,7 @@ module.exports = function usedPropTypesInstructions(context, components, utils) 
     JSXSpreadAttribute(node) {
       const component = components.get(utils.getParentComponent());
       components.set(component ? component.node : node, {
-        ignoreUnusedPropTypesValidation: true,
+        ignoreUnusedPropTypesValidation: node.argument.type !== 'ObjectExpression',
       });
     },
 

--- a/tests/lib/rules/no-unused-prop-types.js
+++ b/tests/lib/rules/no-unused-prop-types.js
@@ -6689,6 +6689,26 @@ ruleTester.run('no-unused-prop-types', rule, {
         { message: '\'foo\' PropType is defined but prop is never used' },
         { message: '\'propTypes\' PropType is defined but prop is never used' },
       ],
+    },
+    {
+      code: `
+        import React from "react";
+
+        type props = {
+          foo: string;
+          bar: string;
+        };
+
+        const Demo: React.FC<props> = ({ foo }) => {
+          return <div {...{}}>{foo}</div>;
+        };
+
+        export default Demo;
+      `,
+      features: ['ts', 'no-babel'],
+      errors: [
+        { message: '\'bar\' PropType is defined but prop is never used' },
+      ],
     }
   )),
 });


### PR DESCRIPTION
Fixes #3566