### PR TITLE
[New] `hook-use-state`: add option to use useState hook with no value

### DIFF
--- a/lib/rules/hook-use-state.js
+++ b/lib/rules/hook-use-state.js
@@ -41,6 +41,10 @@ module.exports = {
           default: false,
           type: 'boolean',
         },
+        allowNoValue: {
+          default: false,
+          type: 'boolean',
+        },
       },
       additionalProperties: false,
     }],
@@ -51,6 +55,7 @@ module.exports = {
   create: Components.detect((context, components, util) => {
     const configuration = context.options[0] || {};
     const allowDestructuredState = configuration.allowDestructuredState || false;
+    const allowNoValue = configuration.allowNoValue || false;
 
     return {
       CallExpression(node) {
@@ -84,6 +89,10 @@ module.exports = {
         const isOnlyValueDestructuring = isNodeDestructuring(valueVariable) && !isNodeDestructuring(setterVariable);
 
         if (allowDestructuredState && isOnlyValueDestructuring) {
+          return;
+        }
+
+        if (allowNoValue && !valueVariable) {
           return;
         }
 

--- a/tests/lib/rules/hook-use-state.js
+++ b/tests/lib/rules/hook-use-state.js
@@ -193,6 +193,16 @@ const tests = {
       `,
       options: [{ allowDestructuredState: true }],
     },
+    {
+      code: `
+        import { useState } from 'react'
+        function useForceUpdate() {
+          const [, forceUpdate] = useState({})
+          return forceUpdate
+        }
+      `,
+      options: [{ allowNoValue: true }],
+    },
   ]),
   invalid: parsers.all([
     {


### PR DESCRIPTION
This is useful if you want to forcibly re-render a component