### PR TITLE
[Fix] update configuration URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,9 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 
 ### Changed
 * [Docs] [`jsx-newline`], [`no-unsafe`], [`static-property-placement`]: Fix code syntax highlighting ([#3563][] @nbsp1221)
+* [readme] resore configuration URL ([#3582][] @gokaygurcan)
 
+[#3582]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3582
 [#3570]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3570
 [#3568]: https://github.com/jsx-eslint/eslint-plugin-react/issues/3568
 [#3563]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3563

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ npm install eslint eslint-plugin-react --save-dev
 
 It is also possible to install ESLint globally rather than locally (using `npm install -g eslint`). However, this is not recommended, and any plugins or shareable configs that you use must be installed locally in either case.
 
-## Configuration (legacy: `.eslintrc*`)
+## Configuration (legacy: `.eslintrc*`) <a id="configuration"></a>
 
 Use [our preset](#recommended) to get reasonable defaults:
 


### PR DESCRIPTION
Hi, 

When I run `eslint` on some React files, this is what I get:

```bash
$ npm run lint:js

> @gokaygurcan/test@1.0.0 lint:js
> eslint --config .eslintrc --color .

Warning: React version not specified in eslint-plugin-react settings. See https://github.com/jsx-eslint/eslint-plugin-react#configuration .
```

And the given URL resolves the repository, but doesn't scroll to the anchored place because of this change: https://github.com/jsx-eslint/eslint-plugin-react/commit/17858beeedaaf5d0eb4fd1cc292fb34d07f9f659#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R20 

This PR is here to fix the URL and point the correct location.

I hope this makes sense. Thanks in advance for your consideration.

Best,
G.