### PR TITLE
[Docs] `jsx-first-prop-new-line`: add missing multiprop value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,9 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 * [Docs] [`jsx-newline`], [`no-unsafe`], [`static-property-placement`]: Fix code syntax highlighting ([#3563][] @nbsp1221)
 * [readme] resore configuration URL ([#3582][] @gokaygurcan)
 * [Docs] [`jsx-no-bind`]: reword performance rationale ([#3581][] @gpoole)
+- [Docs] [`jsx-first-prop-new-line`]: add missing `multiprop` value ([#3598][] @dzek69)
 
+[#3598]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3598
 [#3593]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3593
 [#3583]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3583
 [#3582]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3582

--- a/docs/rules/jsx-first-prop-new-line.md
+++ b/docs/rules/jsx-first-prop-new-line.md
@@ -107,7 +107,7 @@ Examples of **correct** code for this rule, when configured with `"multiline-mul
 ## Rule Options
 
 ```jsx
-"react/jsx-first-prop-new-line": `"always" | "never" | "multiline" | "multiline-multiprop"`
+"react/jsx-first-prop-new-line": `"always" | "never" | "multiline" | "multiprop" | "multiline-multiprop"`
 ```
 
 ## When Not To Use It


### PR DESCRIPTION
Added missing possible value, The value is listed near the top of the docs document, but not near the bottom