### PR TITLE
[actions] Replace `set-output` commands with environment files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Get version from tag
         id: tag_name
-        run: echo ::set-output name=current_version::${GITHUB_REF#refs/tags/v}
+        run: echo "current_version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
         shell: bash
 
       - uses: actions/checkout@v3
@@ -42,7 +42,10 @@ jobs:
           _links="${_links//$'\n'/'%0A'}"
           _links="${_links//$'\r'/'%0D'}"
           # Set output 'links' to $_links
-          echo "::set-output name=links::${_links}"
+          DELIMITER=$(uuidgen)
+          echo "links<<${DELIMITER}" >> "${GITHUB_OUTPUT}"
+          echo "$_links" >> "${GITHUB_OUTPUT}"
+          echo "${DELIMITER}" >> "${GITHUB_OUTPUT}"
 
       - uses: softprops/action-gh-release@v1
         with:


### PR DESCRIPTION
These commands were deprecated awhile back, removing them will also get rid of the warnings in the run log.

- https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
- https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings