### PR TITLE
[Fix] `require-default-props`: fix config schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 
 ## Unreleased
 
+### Fixed
+* [`require-default-props`]: fix config schema ([#3605][] @controversial)
+
+[#3605]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3605
+
 ## [7.33.0] - 2023.07.19
 
 ### Added

--- a/lib/rules/require-default-props.js
+++ b/lib/rules/require-default-props.js
@@ -41,14 +41,10 @@ module.exports = {
           type: 'boolean',
         },
         classes: {
-          allow: {
-            enum: ['defaultProps', 'ignore'],
-          },
+          enum: ['defaultProps', 'ignore'],
         },
         functions: {
-          allow: {
-            enum: ['defaultArguments', 'defaultProps', 'ignore'],
-          },
+          enum: ['defaultArguments', 'defaultProps', 'ignore'],
         },
         /**
          * @deprecated


### PR DESCRIPTION
Fix #3604 

Removes extraneous “allow” keyword from JSON schema definition. I couldn’t find any references to this keyword in JSON schema, nor documentation on its purpose, but it seems to break the TypeScript definitions generated in projects like [eslint-define-config](https://github.com/Shinigami92/eslint-define-config).

If the “allow” keyword has a purpose here that I’m not aware of, please feel free to close this PR.