### PR TITLE
[actions]: use issue label on smoke tests

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -19,7 +19,8 @@ jobs:
       - run: |
           npm link
           npm link eslint-plugin-react
-      - uses: AriPerkkio/eslint-remote-tester-run-action@v3
+      - uses: AriPerkkio/eslint-remote-tester-run-action@v4
         with:
           issue-title: 'Results of weekly scheduled smoke test'
+          issue-label: 'smoke-test'
           eslint-remote-tester-config: test/eslint-remote-tester.config.js


### PR DESCRIPTION
Adds issue labels for smoke tests. This allows renaming the issues created by bot, and still be able to receive next week's results on the same issue.

- Ref. https://github.com/jsx-eslint/eslint-plugin-react/issues/3637
- Ref. https://github.com/jsx-eslint/eslint-plugin-react/issues/3632

Updates `eslint-remote-tester-run-action` from v3 to v4.1:
- https://github.com/AriPerkkio/eslint-remote-tester-run-action/releases/tag/v4
- https://github.com/AriPerkkio/eslint-remote-tester-run-action/releases/tag/v4.1.0