### PR TITLE
Add displaystyle as known property on math elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 * [`sort-prop-types`]: give errors on TS types ([#3615][] @akulsr0)
 * [`no-invalid-html-attribute`]: add support for `apple-touch-startup-image` `rel` attributes in `link` tags ([#3638][] @thomashockaday)
 * [`no-unknown-property`]: add requireDataLowercase option ([#3645][] @HermanBilous)
+* [`no-unknown-property`]: add `displaystyle` on `<math>` ([#3652][] @lounsbrough)
 
 ### Fixed
 * [`jsx-no-leaked-render`]: preserve RHS parens for multiline jsx elements while fixing ([#3623][] @akulsr0)
@@ -21,6 +22,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 * [Refactor] [`function-component-definition`]: exit early if no type params ([#3634][] @HenryBrown0)
 * [Refactor] [`jsx-props-no-multi-spaces`]: extract type parameters to var ([#3634][] @HenryBrown0)
 
+[#3652]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3652
 [#3645]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3645
 [#3638]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3638
 [#3634]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3634

--- a/lib/rules/no-unknown-property.js
+++ b/lib/rules/no-unknown-property.js
@@ -34,6 +34,7 @@ const ATTRIBUTE_TAGS_MAP = {
   checked: ['input'],
   // image is required for SVG support, all other tags are HTML.
   crossOrigin: ['script', 'img', 'video', 'audio', 'link', 'image'],
+  displaystyle: ['math'],
   // https://html.spec.whatwg.org/multipage/links.html#downloading-resources
   download: ['a', 'area'],
   fill: [ // https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/fill

--- a/tests/lib/rules/no-unknown-property.js
+++ b/tests/lib/rules/no-unknown-property.js
@@ -161,6 +161,7 @@ ruleTester.run('no-unknown-property', rule, {
     { code: '<fbt desc="foo" doNotExtract />;' },
     // fbs
     { code: '<fbs desc="foo" doNotExtract />;' },
+    { code: '<math displaystyle="true" />;' },
   ]),
   invalid: parsers.all([
     {


### PR DESCRIPTION
The `math` element supports a property called `displaystyle` which is not currently recognized by the `no-unknown-property` rule.

https://developer.mozilla.org/en-US/docs/Web/MathML/Global_attributes/displaystyle