### PR TITLE
[Docs] `jsx-key`: fix correct example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,9 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 * [Refactor] [`boolean-prop-naming`]: invert if statement ([#3634][] @HenryBrown0)
 * [Refactor] [`function-component-definition`]: exit early if no type params ([#3634][] @HenryBrown0)
 * [Refactor] [`jsx-props-no-multi-spaces`]: extract type parameters to var ([#3634][] @HenryBrown0)
+* [Docs] [`jsx-key`]: fix correct example ([#3656][] @developer-bandi)
 
+[#3656]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3656
 [#3654]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3654
 [#3652]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3652
 [#3645]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3645

--- a/docs/rules/jsx-key.md
+++ b/docs/rules/jsx-key.md
@@ -40,7 +40,7 @@ data.map((x) => <Hello key={x.id}>{x}</Hello>);
 ```
 
 ```jsx
-Array.from([1, 2, 3], (x) => <Hello key={x.id}>{x}</Hello>);
+Array.from([1, 2, 3], (x) => <Hello key={x}>{x}</Hello>);
 ```
 
 ```jsx


### PR DESCRIPTION
In the 3rd item of the correct example, `x.id` is used as the key. However, since an number type array is entered in Array.from, x is a number, all keys have undefined. Additionally, searching the number property is generally considered an error in TypeScript.

Therefore, the key was modified to use `x` itself so that the key has a unique value and does not cause an error in TypeScript.