### PR TITLE
[New] `jsx-wrap-multilines`: add `never` option to prohibit wrapping parens on multiline JSX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 * [`no-unknown-property`]: add `displaystyle` on `<math>` ([#3652][] @lounsbrough)
 * [`prefer-read-only-props`], [`prop-types`], component detection: allow components to be async functions ([#3654][] @pnodet)
 * [`no-unknown-property`]: support `onResize` on audio/video tags ([#3662][] @caesar1030)
+* [`jsx-wrap-multilines`]: add `never` option to prohibit wrapping parens on multiline JSX ([#3668][] @reedws)
 
 ### Fixed
 * [`jsx-no-leaked-render`]: preserve RHS parens for multiline jsx elements while fixing ([#3623][] @akulsr0)
@@ -26,6 +27,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 * [Refactor] [`jsx-props-no-multi-spaces`]: extract type parameters to var ([#3634][] @HenryBrown0)
 * [Docs] [`jsx-key`]: fix correct example ([#3656][] @developer-bandi)
 
+[#3668]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3668
 [#3666]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3666
 [#3662]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3662
 [#3656]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3656

--- a/docs/rules/jsx-wrap-multilines.md
+++ b/docs/rules/jsx-wrap-multilines.md
@@ -50,7 +50,7 @@ var Hello = createReactClass({
 });
 ```
 
-Examples of **correct** code for this rule:
+Examples of **correct** code for this rule, when configured with either `parens` or `parens-new-line`:
 
 ```jsx
 var singleLineJSX = <p>Hello</p>
@@ -62,6 +62,36 @@ var Hello = createReactClass({
         <p>Hello {this.props.name}</p>
       </div>
     );
+  }
+});
+```
+
+Examples of **incorrect** code for this rule, when configured with `never`:
+
+```jsx
+var singleLineJSX = <p>Hello</p>
+
+var Hello = createReactClass({
+  render: function() {
+    return (
+      <div>
+        <p>Hello {this.props.name}</p>
+      </div>
+    );
+  }
+});
+```
+
+Examples of **correct** code for this rule, when configured with `never`:
+
+```jsx
+var singleLineJSX = <p>Hello</p>
+
+var Hello = createReactClass({
+  render: function() {
+    return <div>
+      <p>Hello {this.props.name}</p>
+    </div>;
   }
 });
 ```
@@ -114,6 +144,30 @@ var hello = (
     <p>Hello</p>
   </div>
 );
+```
+
+Examples of **incorrect** code for this rule, when configured with `{ declaration: "never" }`:
+
+```jsx
+var hello = (<div>
+  <p>Hello</p>
+</div>);
+```
+
+```jsx
+var hello = (
+  <div>
+    <p>Hello</p>
+  </div>
+);
+```
+
+Examples of **correct** code for this rule, when configured with `{ declaration: "never" }`.
+
+```jsx
+var hello = <div>
+  <p>Hello</p>
+</div>;
 ```
 
 ### `assignment`
@@ -170,6 +224,33 @@ hello = (
     <p>Hello</p>
   </div>
 );
+```
+
+Examples of **incorrect** code for this rule, when configured with `{ assignment: "never" }`.
+
+```jsx
+var hello;
+hello = (<div>
+  <p>Hello</p>
+</div>);
+```
+
+```jsx
+var hello;
+hello = (
+  <div>
+    <p>Hello</p>
+  </div>
+);
+```
+
+Examples of **correct** code for this rule, when configured with `{ assignment: "never" }`.
+
+```jsx
+var hello;
+hello = <div>
+  <p>Hello</p>
+</div>;
 ```
 
 ### `return`
@@ -234,6 +315,36 @@ function hello() {
 }
 ```
 
+Examples of **incorrect** code for this rule, when configured with `{ return: "never" }`.
+
+```jsx
+function hello() {
+  return (<div>
+    <p>Hello</p>
+  </div>);
+}
+```
+
+```jsx
+function hello() {
+  return (
+    <div>
+      <p>Hello</p>
+    </div>
+  );
+}
+```
+
+Examples of **correct** code for this rule, when configured with `{ return: "never" }`.
+
+```jsx
+function hello() {
+  return <div>
+    <p>Hello</p>
+  </div>;
+}
+```
+
 ### `arrow`
 
 Examples of **incorrect** code for this rule, when configured with `{ arrow: "parens" }`.
@@ -282,6 +393,30 @@ var hello = () => (
     <p>World</p>
   </div>
 );
+```
+
+Examples of **incorrect** code for this rule, when configured with `{ arrow: "never" }`.
+
+```jsx
+var hello = () => (<div>
+  <p>World</p>
+</div>);
+```
+
+```jsx
+var hello = () => (
+  <div>
+    <p>World</p>
+  </div>
+);
+```
+
+Examples of **correct** code for this rule, when configured with `{ arrow: "never" }`.
+
+```jsx
+var hello = () => <div>
+  <p>World</p>
+</div>;
 ```
 
 ### `condition`
@@ -343,6 +478,36 @@ Examples of **correct** code for this rule, when configured with `{ condition: "
       <p>Hello</p>
     </div>
   ): null}
+</div>
+```
+
+Examples of **incorrect** code for this rule, when configured with `{ condition: "never" }`.
+
+```jsx
+<div>
+  {foo ? (<div>
+      <p>Hello</p>
+  </div>) : null}
+</div>
+```
+
+```jsx
+<div>
+  {foo ? (
+    <div>
+      <p>Hello</p>
+    </div>
+  ): null}
+</div>
+```
+
+Examples of **correct** code for this rule, when configured with `{ condition: "never" }`.
+
+```jsx
+<div>
+  {foo ? <div>
+      <p>Hello</p>
+    </div> : null}
 </div>
 ```
 
@@ -416,6 +581,40 @@ Examples of **correct** code for this rule, when configured with `{ logical: "pa
 </div>
 ```
 
+Examples of **incorrect** code for this rule, when configured with `{ logical: "never" }`.
+
+```jsx
+<div>
+  {foo &&
+    (<div>
+      <p>Hello World</p>
+    </div>)
+  }
+</div>
+```
+
+```jsx
+<div>
+  {foo && (
+    <div>
+      <p>Hello World</p>
+    </div>
+  )}
+</div>
+```
+
+Examples of **correct** code for this rule, when configured with `{ logical: "never" }`.
+
+```jsx
+<div>
+  {foo &&
+    <div>
+      <p>Hello World</p>
+    </div>
+  }
+</div>
+```
+
 ### `prop`
 
 Examples of **incorrect** code for this rule, when configured with `{ prop: "parens" }`.
@@ -474,6 +673,36 @@ Examples of **correct** code for this rule, when configured with `{ prop: "paren
     <p>Hello</p>
   </div>
 )}>
+  <p>Hello</p>
+</div>;
+```
+
+Examples of **incorrect** code for this rule, when configured with `{ prop: "never" }`.
+
+```jsx
+<div foo={(<div>
+    <p>Hello</p>
+  </div>)}>
+  <p>Hello</p>
+</div>;
+```
+
+```jsx
+<div foo={(
+  <div>
+    <p>Hello</p>
+  </div>
+)}>
+  <p>Hello</p>
+</div>;
+```
+
+Examples of **correct** code for this rule, when configured with `{ prop: "never" }`.
+
+```jsx
+<div foo={<div>
+    <p>Hello</p>
+  </div>}>
   <p>Hello</p>
 </div>;
 ```

--- a/lib/rules/jsx-wrap-multilines.js
+++ b/lib/rules/jsx-wrap-multilines.js
@@ -31,6 +31,7 @@ const DEFAULTS = {
 
 const messages = {
   missingParens: 'Missing parentheses around multilines JSX',
+  extraParens: 'Expected no parentheses around multilines JSX',
   parensOnNewLines: 'Parentheses around JSX should be on separate lines',
 };
 
@@ -51,25 +52,25 @@ module.exports = {
       // true/false are for backwards compatibility
       properties: {
         declaration: {
-          enum: [true, false, 'ignore', 'parens', 'parens-new-line'],
+          enum: [true, false, 'ignore', 'parens', 'parens-new-line', 'never'],
         },
         assignment: {
-          enum: [true, false, 'ignore', 'parens', 'parens-new-line'],
+          enum: [true, false, 'ignore', 'parens', 'parens-new-line', 'never'],
         },
         return: {
-          enum: [true, false, 'ignore', 'parens', 'parens-new-line'],
+          enum: [true, false, 'ignore', 'parens', 'parens-new-line', 'never'],
         },
         arrow: {
-          enum: [true, false, 'ignore', 'parens', 'parens-new-line'],
+          enum: [true, false, 'ignore', 'parens', 'parens-new-line', 'never'],
         },
         condition: {
-          enum: [true, false, 'ignore', 'parens', 'parens-new-line'],
+          enum: [true, false, 'ignore', 'parens', 'parens-new-line', 'never'],
         },
         logical: {
-          enum: [true, false, 'ignore', 'parens', 'parens-new-line'],
+          enum: [true, false, 'ignore', 'parens', 'parens-new-line', 'never'],
         },
         prop: {
-          enum: [true, false, 'ignore', 'parens', 'parens-new-line'],
+          enum: [true, false, 'ignore', 'parens', 'parens-new-line', 'never'],
         },
       },
       additionalProperties: false,
@@ -183,6 +184,15 @@ module.exports = {
             });
           }
         }
+      }
+
+      if (option === 'never' && isParenthesized(context, node)) {
+        const tokenBefore = sourceCode.getTokenBefore(node);
+        const tokenAfter = sourceCode.getTokenAfter(node);
+        report(node, 'extraParens', (fixer) => fixer.replaceTextRange(
+          [tokenBefore.range[0], tokenAfter.range[1]],
+          sourceCode.getText(node)
+        ));
       }
     }
 

--- a/tests/lib/rules/jsx-wrap-multilines.js
+++ b/tests/lib/rules/jsx-wrap-multilines.js
@@ -36,6 +36,16 @@ const OPTIONS_ALL_NEW_LINES = {
   prop: 'parens-new-line',
 };
 
+const OPTIONS_ALL_NEVER = {
+  declaration: 'never',
+  assignment: 'never',
+  return: 'never',
+  arrow: 'never',
+  condition: 'never',
+  logical: 'never',
+  prop: 'never',
+};
+
 const RETURN_SINGLE_LINE = `
   var Hello = createReactClass({
     render: function() {
@@ -631,8 +641,17 @@ ruleTester.run('jsx-wrap-multilines', rule, {
       code: RETURN_SINGLE_LINE,
     },
     {
+      code: RETURN_SINGLE_LINE,
+      options: [OPTIONS_ALL_NEVER],
+    },
+    {
       code: RETURN_SINGLE_LINE_FRAGMENT,
       features: ['fragment'],
+    },
+    {
+      code: RETURN_SINGLE_LINE_FRAGMENT,
+      features: ['fragment'],
+      options: [OPTIONS_ALL_NEVER],
     },
     {
       code: RETURN_PAREN,
@@ -656,10 +675,18 @@ ruleTester.run('jsx-wrap-multilines', rule, {
     },
     {
       code: RETURN_NO_PAREN,
+      options: [OPTIONS_ALL_NEVER],
+    },
+    {
+      code: RETURN_NO_PAREN,
       options: [{ return: false }],
     },
     {
       code: DECLARATION_TERNARY_SINGLE_LINE,
+    },
+    {
+      code: DECLARATION_TERNARY_SINGLE_LINE,
+      options: [OPTIONS_ALL_NEVER],
     },
     {
       code: DECLARATION_TERNARY_SINGLE_LINE_FRAGMENT,
@@ -682,10 +709,18 @@ ruleTester.run('jsx-wrap-multilines', rule, {
     },
     {
       code: DECLARATION_TERNARY_NO_PAREN,
+      options: [OPTIONS_ALL_NEVER],
+    },
+    {
+      code: DECLARATION_TERNARY_NO_PAREN,
       options: [{ declaration: false }],
     },
     {
       code: ASSIGNMENT_TERNARY_SINGLE_LINE,
+    },
+    {
+      code: ASSIGNMENT_TERNARY_SINGLE_LINE,
+      options: [OPTIONS_ALL_NEVER],
     },
     {
       code: ASSIGNMENT_TERNARY_PAREN,
@@ -704,10 +739,18 @@ ruleTester.run('jsx-wrap-multilines', rule, {
     },
     {
       code: ASSIGNMENT_TERNARY_NO_PAREN,
+      options: [OPTIONS_ALL_NEVER],
+    },
+    {
+      code: ASSIGNMENT_TERNARY_NO_PAREN,
       options: [{ assignment: false }],
     },
     {
       code: DECLARATION_SINGLE_LINE,
+    },
+    {
+      code: DECLARATION_SINGLE_LINE,
+      options: [OPTIONS_ALL_NEVER],
     },
     {
       code: DECLARATION_PAREN,
@@ -729,9 +772,18 @@ ruleTester.run('jsx-wrap-multilines', rule, {
       options: [{ declaration: 'ignore' }],
     },
     {
+      code: DECLARATION_NO_PAREN,
+      options: [OPTIONS_ALL_NEVER],
+    },
+    {
       code: DECLARATION_NO_PAREN_FRAGMENT,
       features: ['fragment'],
       options: [{ declaration: 'ignore' }],
+    },
+    {
+      code: DECLARATION_NO_PAREN_FRAGMENT,
+      features: ['fragment'],
+      options: [OPTIONS_ALL_NEVER],
     },
     {
       code: DECLARATION_NO_PAREN,
@@ -740,6 +792,10 @@ ruleTester.run('jsx-wrap-multilines', rule, {
     {
       code: ASSIGNMENT_SINGLE_LINE,
       options: [{ declaration: 'ignore' }],
+    },
+    {
+      code: ASSIGNMENT_SINGLE_LINE,
+      options: [OPTIONS_ALL_NEVER],
     },
     {
       code: ASSIGNMENT_SINGLE_LINE,
@@ -761,9 +817,18 @@ ruleTester.run('jsx-wrap-multilines', rule, {
       options: [{ assignment: 'ignore' }],
     },
     {
+      code: ASSIGNMENT_NO_PAREN,
+      options: [OPTIONS_ALL_NEVER],
+    },
+    {
       code: ASSIGNMENT_NO_PAREN_FRAGMENT,
       features: ['fragment'],
       options: [{ assignment: 'ignore' }],
+    },
+    {
+      code: ASSIGNMENT_NO_PAREN_FRAGMENT,
+      features: ['fragment'],
+      options: [OPTIONS_ALL_NEVER],
     },
     {
       code: ASSIGNMENT_NO_PAREN,
@@ -792,9 +857,18 @@ ruleTester.run('jsx-wrap-multilines', rule, {
       options: [{ arrow: 'ignore' }],
     },
     {
+      code: ARROW_NO_PAREN,
+      options: [OPTIONS_ALL_NEVER],
+    },
+    {
       code: ARROW_NO_PAREN_FRAGMENT,
       features: ['fragment'],
       options: [{ arrow: 'ignore' }],
+    },
+    {
+      code: ARROW_NO_PAREN_FRAGMENT,
+      features: ['fragment'],
+      options: [OPTIONS_ALL_NEVER],
     },
     {
       code: ARROW_NO_PAREN,
@@ -805,10 +879,18 @@ ruleTester.run('jsx-wrap-multilines', rule, {
     },
     {
       code: CONDITION_SINGLE_LINE,
+      options: [OPTIONS_ALL_NEVER],
+    },
+    {
+      code: CONDITION_SINGLE_LINE,
       options: [{ condition: true }],
     },
     {
       code: CONDITION_NO_PAREN,
+    },
+    {
+      code: CONDITION_NO_PAREN,
+      options: [OPTIONS_ALL_NEVER],
     },
     {
       code: CONDITION_PAREN,
@@ -823,7 +905,15 @@ ruleTester.run('jsx-wrap-multilines', rule, {
       code: LOGICAL_SINGLE_LINE,
     },
     {
+      code: LOGICAL_SINGLE_LINE,
+      options: [OPTIONS_ALL_NEVER],
+    },
+    {
       code: LOGICAL_NO_PAREN,
+    },
+    {
+      code: LOGICAL_NO_PAREN,
+      options: [OPTIONS_ALL_NEVER],
     },
     {
       code: LOGICAL_PAREN,
@@ -838,7 +928,15 @@ ruleTester.run('jsx-wrap-multilines', rule, {
       code: ATTR_SINGLE_LINE,
     },
     {
+      code: ATTR_SINGLE_LINE,
+      options: [OPTIONS_ALL_NEVER],
+    },
+    {
       code: ATTR_NO_PAREN,
+    },
+    {
+      code: ATTR_NO_PAREN,
+      options: [OPTIONS_ALL_NEVER],
     },
     {
       code: ATTR_PAREN,
@@ -894,6 +992,12 @@ ruleTester.run('jsx-wrap-multilines', rule, {
 
   invalid: parsers.all([
     {
+      code: RETURN_PAREN,
+      output: RETURN_NO_PAREN,
+      options: [OPTIONS_ALL_NEVER],
+      errors: [{ messageId: 'extraParens' }],
+    },
+    {
       code: RETURN_NO_PAREN,
       output: RETURN_PAREN,
       errors: [{ messageId: 'missingParens' }],
@@ -903,6 +1007,13 @@ ruleTester.run('jsx-wrap-multilines', rule, {
       features: ['fragment'],
       output: RETURN_PAREN_FRAGMENT,
       errors: [{ messageId: 'missingParens' }],
+    },
+    {
+      code: RETURN_PAREN_FRAGMENT,
+      features: ['fragment'],
+      output: RETURN_NO_PAREN_FRAGMENT,
+      options: [OPTIONS_ALL_NEVER],
+      errors: [{ messageId: 'extraParens' }],
     },
     {
       code: RETURN_NO_PAREN,
@@ -926,12 +1037,31 @@ ruleTester.run('jsx-wrap-multilines', rule, {
       ],
     },
     {
+      code: DECLARATION_TERNARY_PAREN,
+      output: DECLARATION_TERNARY_NO_PAREN,
+      options: [OPTIONS_ALL_NEVER],
+      errors: [
+        { messageId: 'extraParens' },
+        { messageId: 'extraParens' },
+      ],
+    },
+    {
       code: DECLARATION_TERNARY_NO_PAREN_FRAGMENT,
       features: ['fragment'],
       output: DECLARATION_TERNARY_PAREN_FRAGMENT,
       errors: [
         { messageId: 'missingParens' },
         { messageId: 'missingParens' },
+      ],
+    },
+    {
+      code: DECLARATION_TERNARY_PAREN_FRAGMENT,
+      features: ['fragment'],
+      output: DECLARATION_TERNARY_NO_PAREN_FRAGMENT,
+      options: [OPTIONS_ALL_NEVER],
+      errors: [
+        { messageId: 'extraParens' },
+        { messageId: 'extraParens' },
       ],
     },
     {
@@ -962,12 +1092,31 @@ ruleTester.run('jsx-wrap-multilines', rule, {
       ],
     },
     {
+      code: ASSIGNMENT_TERNARY_PAREN,
+      output: ASSIGNMENT_TERNARY_NO_PAREN,
+      options: [OPTIONS_ALL_NEVER],
+      errors: [
+        { messageId: 'extraParens' },
+        { messageId: 'extraParens' },
+      ],
+    },
+    {
       code: ASSIGNMENT_TERNARY_NO_PAREN_FRAGMENT,
       features: ['fragment'],
       output: ASSIGNMENT_TERNARY_PAREN_FRAGMENT,
       errors: [
         { messageId: 'missingParens' },
         { messageId: 'missingParens' },
+      ],
+    },
+    {
+      code: ASSIGNMENT_TERNARY_PAREN_FRAGMENT,
+      features: ['fragment'],
+      output: ASSIGNMENT_TERNARY_NO_PAREN_FRAGMENT,
+      options: [OPTIONS_ALL_NEVER],
+      errors: [
+        { messageId: 'extraParens' },
+        { messageId: 'extraParens' },
       ],
     },
     {
@@ -995,10 +1144,23 @@ ruleTester.run('jsx-wrap-multilines', rule, {
       errors: [{ messageId: 'missingParens' }],
     },
     {
+      code: DECLARATION_PAREN,
+      output: DECLARATION_NO_PAREN,
+      options: [OPTIONS_ALL_NEVER],
+      errors: [{ messageId: 'extraParens' }],
+    },
+    {
       code: DECLARATION_NO_PAREN_FRAGMENT,
       features: ['fragment'],
       output: DECLARATION_PAREN_FRAGMENT,
       errors: [{ messageId: 'missingParens' }],
+    },
+    {
+      code: DECLARATION_PAREN_FRAGMENT,
+      features: ['fragment'],
+      output: DECLARATION_NO_PAREN_FRAGMENT,
+      options: [OPTIONS_ALL_NEVER],
+      errors: [{ messageId: 'extraParens' }],
     },
     {
       code: DECLARATION_NO_PAREN,
@@ -1024,15 +1186,34 @@ ruleTester.run('jsx-wrap-multilines', rule, {
       errors: [{ messageId: 'missingParens' }],
     },
     {
+      code: ASSIGNMENT_PAREN,
+      output: ASSIGNMENT_NO_PAREN,
+      options: [OPTIONS_ALL_NEVER],
+      errors: [{ messageId: 'extraParens' }],
+    },
+    {
       code: ARROW_NO_PAREN,
       output: ARROW_PAREN,
       errors: [{ messageId: 'missingParens' }],
+    },
+    {
+      code: ARROW_PAREN,
+      output: ARROW_NO_PAREN,
+      options: [OPTIONS_ALL_NEVER],
+      errors: [{ messageId: 'extraParens' }],
     },
     {
       code: ARROW_NO_PAREN_FRAGMENT,
       features: ['fragment'],
       output: ARROW_PAREN_FRAGMENT,
       errors: [{ messageId: 'missingParens' }],
+    },
+    {
+      code: ARROW_PAREN_FRAGMENT,
+      features: ['fragment'],
+      output: ARROW_NO_PAREN_FRAGMENT,
+      options: [OPTIONS_ALL_NEVER],
+      errors: [{ messageId: 'extraParens' }],
     },
     {
       code: ARROW_NO_PAREN,
@@ -1047,11 +1228,24 @@ ruleTester.run('jsx-wrap-multilines', rule, {
       errors: [{ messageId: 'missingParens' }],
     },
     {
+      code: CONDITION_PAREN,
+      output: CONDITION_NO_PAREN,
+      options: [OPTIONS_ALL_NEVER],
+      errors: [{ messageId: 'extraParens' }],
+    },
+    {
       code: CONDITION_NO_PAREN_FRAGMENT,
       features: ['fragment'],
       output: CONDITION_PAREN_FRAGMENT,
       options: [{ condition: 'parens' }],
       errors: [{ messageId: 'missingParens' }],
+    },
+    {
+      code: CONDITION_PAREN_FRAGMENT,
+      features: ['fragment'],
+      output: CONDITION_NO_PAREN_FRAGMENT,
+      options: [OPTIONS_ALL_NEVER],
+      errors: [{ messageId: 'extraParens' }],
     },
     {
       code: CONDITION_NO_PAREN,
@@ -1066,11 +1260,24 @@ ruleTester.run('jsx-wrap-multilines', rule, {
       errors: [{ messageId: 'missingParens' }],
     },
     {
+      code: LOGICAL_PAREN,
+      output: LOGICAL_NO_PAREN,
+      options: [OPTIONS_ALL_NEVER],
+      errors: [{ messageId: 'extraParens' }],
+    },
+    {
       code: LOGICAL_NO_PAREN_FRAGMENT,
       features: ['fragment'],
       output: LOGICAL_PAREN_FRAGMENT,
       options: [{ logical: 'parens' }],
       errors: [{ messageId: 'missingParens' }],
+    },
+    {
+      code: LOGICAL_PAREN_FRAGMENT,
+      features: ['fragment'],
+      output: LOGICAL_NO_PAREN_FRAGMENT,
+      options: [OPTIONS_ALL_NEVER],
+      errors: [{ messageId: 'extraParens' }],
     },
     {
       code: LOGICAL_NO_PAREN,
@@ -1085,11 +1292,24 @@ ruleTester.run('jsx-wrap-multilines', rule, {
       errors: [{ messageId: 'missingParens' }],
     },
     {
+      code: ATTR_PAREN,
+      output: ATTR_NO_PAREN,
+      options: [OPTIONS_ALL_NEVER],
+      errors: [{ messageId: 'extraParens' }],
+    },
+    {
       code: ATTR_NO_PAREN_FRAGMENT,
       features: ['fragment'],
       output: ATTR_PAREN_FRAGMENT,
       options: [{ prop: 'parens' }],
       errors: [{ messageId: 'missingParens' }],
+    },
+    {
+      code: ATTR_PAREN_FRAGMENT,
+      features: ['fragment'],
+      output: ATTR_NO_PAREN_FRAGMENT,
+      options: [OPTIONS_ALL_NEVER],
+      errors: [{ messageId: 'extraParens' }],
     },
     {
       code: ATTR_NO_PAREN,


### PR DESCRIPTION
Fixes #1035 

First PR here so if I'm missing anything please let me know!
(Also I'm aware this particular option is very controversial, please don't hate me 😇)