### PR TITLE
[Fix] add a few jsdoc type annotations to work around TS inference bugs for consumers

### DIFF
--- a/configs/all.js
+++ b/configs/all.js
@@ -9,6 +9,10 @@ function filterRules(rules, predicate) {
   return fromEntries(entries(rules).filter((entry) => predicate(entry[1])));
 }
 
+/**
+ * @param {object} rules - rules object mapping rule name to rule module
+ * @returns {Record<string, 2>}
+ */
 function configureAsError(rules) {
   return fromEntries(Object.keys(rules).map((key) => [`react/${key}`, 2]));
 }
@@ -20,6 +24,12 @@ const deprecatedRules = filterRules(allRules, (rule) => rule.meta.deprecated);
 
 module.exports = {
   plugins: {
+    /**
+     * @type {{
+     *   deprecatedRules: Record<string, import('eslint').Rule.RuleModule>,
+     *   rules: Record<string, import('eslint').Rule.RuleModule>,
+     * }}
+     */
     react: {
       deprecatedRules,
       rules: allRules,

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -2,6 +2,7 @@
 
 /* eslint global-require: 0 */
 
+/** @type {Record<string, import('eslint').Rule.RuleModule>} */
 module.exports = {
   'boolean-prop-naming': require('./boolean-prop-naming'),
   'button-has-type': require('./button-has-type'),


### PR DESCRIPTION
Figured I'd split this out of #3694

This PR adds a few JSDoc type annotations to hint to TS what the types are. This helps work-around issues like https://github.com/typescript-eslint/typescript-eslint/issues/8522 / https://github.com/microsoft/TypeScript/issues/57460 where TS would infer the wrong type from the JS and would break strictly-typed config files.