### PR TITLE
[Fix] `boolean-prop-naming`: detect TS interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 
 ### Fixed
 * [`jsx-no-leaked-render`]: prevent wrongly adding parens ([#3700][] @developer-bandi)
+* [`boolean-prop-naming`]: detect TS interfaces ([#3701][] @developer-bandi)
 
+[#3701]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3701
 [#3700]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3700
 
 ## [7.34.0] - 2024.03.03

--- a/lib/rules/boolean-prop-naming.js
+++ b/lib/rules/boolean-prop-naming.js
@@ -264,7 +264,7 @@ module.exports = {
     }
 
     function findAllTypeAnnotations(identifier, node) {
-      if (node.type === 'TSTypeLiteral' || node.type === 'ObjectTypeAnnotation') {
+      if (node.type === 'TSTypeLiteral' || node.type === 'ObjectTypeAnnotation' || node.type === 'TSInterfaceBody') {
         const currentNode = [].concat(
           objectTypeAnnotations.get(identifier.name) || [],
           node
@@ -363,6 +363,10 @@ module.exports = {
         findAllTypeAnnotations(node.id, node.typeAnnotation);
       },
 
+      TSInterfaceDeclaration(node) {
+        findAllTypeAnnotations(node.id, node.body);
+      },
+
       // eslint-disable-next-line object-shorthand
       'Program:exit'() {
         if (!rule) {
@@ -386,7 +390,7 @@ module.exports = {
               [].concat(propType).forEach((prop) => {
                 validatePropNaming(
                   component.node,
-                  prop.properties || prop.members
+                  prop.properties || prop.members || prop.body
                 );
               });
             }

--- a/tests/lib/rules/boolean-prop-naming.js
+++ b/tests/lib/rules/boolean-prop-naming.js
@@ -1239,5 +1239,20 @@ ruleTester.run('boolean-prop-naming', rule, {
         },
       ],
     },
+    {
+      code: `
+        interface TestFNType {
+          enabled: boolean
+        }
+        const HelloNew = (props: TestFNType) => { return <div /> };
+    `,
+      options: [{ rule: '^is[A-Z]([A-Za-z0-9]?)+' }],
+      features: ['ts', 'no-babel'],
+      errors: [
+        {
+          message: 'Prop name (enabled) doesn\'t match rule (^is[A-Z]([A-Za-z0-9]?)+)',
+        },
+      ],
+    },
   ]),
 });


### PR DESCRIPTION
related to #3285

in this issue I found four error case. The test case is below:
```
interface Props {
  enabled: boolean
}
const Hello = (props: Props) => <div />;
```

```
const Hello = (props: {enabled:boolean}) => <div />;
```

```
type Props = {
  enabled: boolean
}
const Hello = (props: Props & BaseProps) => <div />;
```

```
type Props = {
  enabled: boolean
}
const Hello: React.FC<Props> = (props) => <div />;
```
Currently, PR is working on the first case fix that corrects the interface error, which is the main content raised in the issue.

I think the code needs to be modified so that all test cases succeed, but it seems like there is many cases to work on at once in this PR, so I am wondering whether this should be done in one PR, or if it can be done in a different PR for each test case.