### PR TITLE
[Fix] `boolean-prop-naming`: literalType error fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 ### Fixed
 * [`jsx-no-leaked-render`]: prevent wrongly adding parens ([#3700][] @developer-bandi)
 * [`boolean-prop-naming`]: detect TS interfaces ([#3701][] @developer-bandi)
+* [`boolean-prop-naming`]: literalType error fix ([#3704][] @developer-bandi)
 
+[#3704]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3704
 [#3701]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3701
 [#3700]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3700
 

--- a/lib/rules/boolean-prop-naming.js
+++ b/lib/rules/boolean-prop-naming.js
@@ -380,7 +380,7 @@ module.exports = {
             let propType;
             if (annotation.type === 'GenericTypeAnnotation') {
               propType = objectTypeAnnotations.get(annotation.id.name);
-            } else if (annotation.type === 'ObjectTypeAnnotation') {
+            } else if (annotation.type === 'ObjectTypeAnnotation' || annotation.type === 'TSTypeLiteral') {
               propType = annotation;
             } else if (annotation.type === 'TSTypeReference') {
               propType = objectTypeAnnotations.get(annotation.typeName.name);

--- a/tests/lib/rules/boolean-prop-naming.js
+++ b/tests/lib/rules/boolean-prop-naming.js
@@ -1254,5 +1254,15 @@ ruleTester.run('boolean-prop-naming', rule, {
         },
       ],
     },
+    {
+      code: 'const Hello = (props: {enabled:boolean}) => <div />;',
+      options: [{ rule: '^(is|has)[A-Z]([A-Za-z0-9]?)+' }],
+      features: ['ts', 'no-babel'],
+      errors: [
+        {
+          message: 'Prop name (enabled) doesn\'t match rule (^(is|has)[A-Z]([A-Za-z0-9]?)+)',
+        },
+      ],
+    },
   ]),
 });


### PR DESCRIPTION
related #3285 As mentioned in #3701, the rule is modified to apply even when the type of props is directly specified.

```
const Hello = (props: {enabled:boolean}) => <div />;
```