### PR TITLE
[Fix] `boolean-prop-naming`: literal TSIntersectionType not allow error fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 * [`jsx-no-leaked-render`]: prevent wrongly adding parens ([#3700][] @developer-bandi)
 * [`boolean-prop-naming`]: detect TS interfaces ([#3701][] @developer-bandi)
 * [`boolean-prop-naming`]: literalType error fix ([#3704][] @developer-bandi)
+* [`boolean-prop-naming`]: allow TSIntersectionType ([#3705][] @developer-bandi)
 
+[#3705]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3705
 [#3704]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3704
 [#3701]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3701
 [#3700]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3700

--- a/lib/rules/boolean-prop-naming.js
+++ b/lib/rules/boolean-prop-naming.js
@@ -5,6 +5,7 @@
 
 'use strict';
 
+const flatMap = require('array.prototype.flatmap');
 const values = require('object.values');
 
 const Components = require('../util/Components');
@@ -384,6 +385,8 @@ module.exports = {
               propType = annotation;
             } else if (annotation.type === 'TSTypeReference') {
               propType = objectTypeAnnotations.get(annotation.typeName.name);
+            } else if (annotation.type === 'TSIntersectionType') {
+              propType = flatMap(annotation.types, (type) => objectTypeAnnotations.get(type.typeName.name));
             }
 
             if (propType) {

--- a/tests/lib/rules/boolean-prop-naming.js
+++ b/tests/lib/rules/boolean-prop-naming.js
@@ -1245,7 +1245,7 @@ ruleTester.run('boolean-prop-naming', rule, {
           enabled: boolean
         }
         const HelloNew = (props: TestFNType) => { return <div /> };
-    `,
+      `,
       options: [{ rule: '^is[A-Z]([A-Za-z0-9]?)+' }],
       features: ['ts', 'no-babel'],
       errors: [
@@ -1261,6 +1261,28 @@ ruleTester.run('boolean-prop-naming', rule, {
       errors: [
         {
           message: 'Prop name (enabled) doesn\'t match rule (^(is|has)[A-Z]([A-Za-z0-9]?)+)',
+        },
+      ],
+    },
+    {
+      code: `
+        type Props = {
+          enabled: boolean
+        }
+        type BaseProps = {
+          semi: boolean
+        }
+        
+        const Hello = (props: Props & BaseProps) => <div />;
+      `,
+      options: [{ rule: '^(is|has)[A-Z]([A-Za-z0-9]?)+' }],
+      features: ['ts', 'no-babel', 'no-ts-old'],
+      errors: [
+        {
+          message: 'Prop name (enabled) doesn\'t match rule (^(is|has)[A-Z]([A-Za-z0-9]?)+)',
+        },
+        {
+          message: 'Prop name (semi) doesn\'t match rule (^(is|has)[A-Z]([A-Za-z0-9]?)+)',
         },
       ],
     },


### PR DESCRIPTION
fix literal TSIntersectionType not allow error like below test case
```
      type Props = {
        enabled: boolean
      }
      type BaseProps = {
        semi: boolean
      }
      
      const Hello = (props: Props & BaseProps) => <div />;`
```
and left one error test case messioned in #3701 is exsit in test code 
```
type Props = {
  enabled: boolean
}
const Hello: React.FC<Props> = (props) => <div />;
```

so I think this pr is merged, the issue #3285 can be closed.