### PR TITLE
[Fix] checked-requires-onchange-or-readonly: correcting option names

### DIFF
--- a/docs/rules/checked-requires-onchange-or-readonly.md
+++ b/docs/rules/checked-requires-onchange-or-readonly.md
@@ -38,7 +38,7 @@ React.createElement('input', { type: 'checkbox', defaultChecked: true });
 
 ```js
 "react/checked-requires-onchange-or-readonly": [<enabled>, {
-  "ignoreMissingProperties": <boolean>,
-  "ignoreExclusiveCheckedAttribute": <boolean>
+  "noMissingProperties": <boolean>,
+  "noExclusiveCheckedAttribute": <boolean>
 }]
 ```

--- a/lib/rules/checked-requires-onchange-or-readonly.js
+++ b/lib/rules/checked-requires-onchange-or-readonly.js
@@ -19,8 +19,8 @@ const messages = {
 const targetPropSet = new Set(['checked', 'onChange', 'readOnly', 'defaultChecked']);
 
 const defaultOptions = {
-  ignoreMissingProperties: true,
-  ignoreExclusiveCheckedAttribute: true,
+  noMissingProperties: true,
+  noExclusiveCheckedAttribute: true,
 };
 
 /**
@@ -53,10 +53,10 @@ module.exports = {
     schema: [{
       additionalProperties: false,
       properties: {
-        ignoreMissingProperties: {
+        noMissingProperties: {
           type: 'boolean',
         },
-        ignoreExclusiveCheckedAttribute: {
+        noExclusiveCheckedAttribute: {
           type: 'boolean',
         },
       },
@@ -93,12 +93,12 @@ module.exports = {
         return;
       }
 
-      if (options.ignoreExclusiveCheckedAttribute && propSet.has('defaultChecked')) {
+      if (options.noExclusiveCheckedAttribute && propSet.has('defaultChecked')) {
         reportExclusiveCheckedAttribute(node);
       }
 
       if (
-        options.ignoreMissingProperties
+        options.noMissingProperties
         && !(propSet.has('onChange') || propSet.has('readOnly'))
       ) {
         reportMissingProperty(node);

--- a/tests/lib/rules/checked-requires-onchange-or-readonly.js
+++ b/tests/lib/rules/checked-requires-onchange-or-readonly.js
@@ -40,19 +40,19 @@ ruleTester.run('checked-requires-onchange-or-readonly', rule, {
     "React.createElement('input', { checked: foo, onChange: noop, readOnly: true })",
     {
       code: '<input type="checkbox" checked />',
-      options: [{ ignoreMissingProperties: false }],
+      options: [{ noMissingProperties: false }],
     },
     {
       code: '<input type="checkbox" checked={true} />',
-      options: [{ ignoreMissingProperties: false }],
+      options: [{ noMissingProperties: false }],
     },
     {
       code: '<input type="checkbox" onChange={noop} checked defaultChecked />',
-      options: [{ ignoreExclusiveCheckedAttribute: false }],
+      options: [{ noExclusiveCheckedAttribute: false }],
     },
     {
       code: '<input type="checkbox" onChange={noop} checked={true} defaultChecked />',
-      options: [{ ignoreExclusiveCheckedAttribute: false }],
+      options: [{ noExclusiveCheckedAttribute: false }],
     },
     '<span/>',
     "React.createElement('span')",
@@ -99,12 +99,12 @@ ruleTester.run('checked-requires-onchange-or-readonly', rule, {
     },
     {
       code: '<input type="checkbox" checked defaultChecked />',
-      options: [{ ignoreMissingProperties: false }],
+      options: [{ noMissingProperties: false }],
       errors: [{ messageId: 'exclusiveCheckedAttribute' }],
     },
     {
       code: '<input type="checkbox" checked defaultChecked />',
-      options: [{ ignoreExclusiveCheckedAttribute: false }],
+      options: [{ noExclusiveCheckedAttribute: false }],
       errors: [{ messageId: 'missingProperty' }],
     },
   ]),


### PR DESCRIPTION
corrected reversely named options 
- `ignoreMissingProperties` -> `noMissingProperties` 
- `ignoreExclusiveCheckedAttribute` -> `noExclusiveCheckedAttribute`