### PR TITLE
[Fix] `checked-requires-onchange-or-readonly`: correct options that were behaving opposite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,12 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 * [`boolean-prop-naming`]: allow TSIntersectionType ([#3705][] @developer-bandi)
 * [`no-unknown-property`]: support `popover`, `popovertarget`, `popovertargetaction` attributes ([#3707][] @ljharb)
 * [`no-unknown-property`]: only match `data-*` attributes containing `-` ([#3713][] @silverwind)
+* [`checked-requires-onchange-or-readonly`]: correct options that were behaving opposite ([#3715][] @jaesoekjjang)
 
 ### Changed
 * [`boolean-prop-naming`]: improve error message (@ljharb)
 
+[#3715]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3715
 [#3713]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3713
 [#3707]: https://github.com/jsx-eslint/eslint-plugin-react/issues/3707
 [#3705]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3705

--- a/lib/rules/checked-requires-onchange-or-readonly.js
+++ b/lib/rules/checked-requires-onchange-or-readonly.js
@@ -19,8 +19,8 @@ const messages = {
 const targetPropSet = new Set(['checked', 'onChange', 'readOnly', 'defaultChecked']);
 
 const defaultOptions = {
-  ignoreMissingProperties: true,
-  ignoreExclusiveCheckedAttribute: true,
+  ignoreMissingProperties: false,
+  ignoreExclusiveCheckedAttribute: false,
 };
 
 /**
@@ -93,12 +93,12 @@ module.exports = {
         return;
       }
 
-      if (options.ignoreExclusiveCheckedAttribute && propSet.has('defaultChecked')) {
+      if (!options.ignoreExclusiveCheckedAttribute && propSet.has('defaultChecked')) {
         reportExclusiveCheckedAttribute(node);
       }
 
       if (
-        options.ignoreMissingProperties
+        !options.ignoreMissingProperties
         && !(propSet.has('onChange') || propSet.has('readOnly'))
       ) {
         reportMissingProperty(node);

--- a/tests/lib/rules/checked-requires-onchange-or-readonly.js
+++ b/tests/lib/rules/checked-requires-onchange-or-readonly.js
@@ -40,19 +40,23 @@ ruleTester.run('checked-requires-onchange-or-readonly', rule, {
     "React.createElement('input', { checked: foo, onChange: noop, readOnly: true })",
     {
       code: '<input type="checkbox" checked />',
-      options: [{ ignoreMissingProperties: false }],
+      options: [{ ignoreMissingProperties: true }],
     },
     {
       code: '<input type="checkbox" checked={true} />',
-      options: [{ ignoreMissingProperties: false }],
+      options: [{ ignoreMissingProperties: true }],
     },
     {
       code: '<input type="checkbox" onChange={noop} checked defaultChecked />',
-      options: [{ ignoreExclusiveCheckedAttribute: false }],
+      options: [{ ignoreExclusiveCheckedAttribute: true }],
     },
     {
       code: '<input type="checkbox" onChange={noop} checked={true} defaultChecked />',
-      options: [{ ignoreExclusiveCheckedAttribute: false }],
+      options: [{ ignoreExclusiveCheckedAttribute: true }],
+    },
+    {
+      code: '<input type="checkbox" onChange={noop} checked defaultChecked />',
+      options: [{ ignoreMissingProperties: true, ignoreExclusiveCheckedAttribute: true }],
     },
     '<span/>',
     "React.createElement('span')",
@@ -99,13 +103,21 @@ ruleTester.run('checked-requires-onchange-or-readonly', rule, {
     },
     {
       code: '<input type="checkbox" checked defaultChecked />',
-      options: [{ ignoreMissingProperties: false }],
+      options: [{ ignoreMissingProperties: true }],
       errors: [{ messageId: 'exclusiveCheckedAttribute' }],
     },
     {
       code: '<input type="checkbox" checked defaultChecked />',
-      options: [{ ignoreExclusiveCheckedAttribute: false }],
+      options: [{ ignoreExclusiveCheckedAttribute: true }],
       errors: [{ messageId: 'missingProperty' }],
+    },
+    {
+      code: '<input type="checkbox" checked defaultChecked />',
+      options: [{ ignoreMissingProperties: false, ignoreExclusiveCheckedAttribute: false }],
+      errors: [
+        { messageId: 'exclusiveCheckedAttribute' },
+        { messageId: 'missingProperty' },
+      ],
     },
   ]),
 });


### PR DESCRIPTION
Fixed options taht were behaving opposite to their meanings