### PR TITLE
[Fix] `boolean-prop-naming`: avoid a crash with a non-TSTypeReference type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,12 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 * [`no-unknown-property`]: support `popover`, `popovertarget`, `popovertargetaction` attributes ([#3707][] @ljharb)
 * [`no-unknown-property`]: only match `data-*` attributes containing `-` ([#3713][] @silverwind)
 * [`checked-requires-onchange-or-readonly`]: correct options that were behaving opposite ([#3715][] @jaesoekjjang)
+* [`boolean-prop-naming`]: avoid a crash with a non-TSTypeReference type ([#3718][] @developer-bandi)
 
 ### Changed
 * [`boolean-prop-naming`]: improve error message (@ljharb)
 
+[#3718]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3718
 [#3715]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3715
 [#3713]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3713
 [#3707]: https://github.com/jsx-eslint/eslint-plugin-react/issues/3707

--- a/lib/rules/boolean-prop-naming.js
+++ b/lib/rules/boolean-prop-naming.js
@@ -387,7 +387,11 @@ module.exports = {
             } else if (annotation.type === 'TSTypeReference') {
               propType = objectTypeAnnotations.get(annotation.typeName.name);
             } else if (annotation.type === 'TSIntersectionType') {
-              propType = flatMap(annotation.types, (type) => objectTypeAnnotations.get(type.typeName.name));
+              propType = flatMap(annotation.types, (type) => (
+                type.type === 'TSTypeReference'
+                  ? objectTypeAnnotations.get(type.typeName.name)
+                  : type
+              ));
             }
 
             if (propType) {

--- a/tests/lib/rules/boolean-prop-naming.js
+++ b/tests/lib/rules/boolean-prop-naming.js
@@ -1312,12 +1312,41 @@ ruleTester.run('boolean-prop-naming', rule, {
       code: `
         type Props = {
           enabled: boolean
-        }
+        };
         type BaseProps = {
           semi: boolean
-        }
+        };
 
         const Hello = (props: Props & BaseProps) => <div />;
+      `,
+      options: [{ rule: '^(is|has)[A-Z]([A-Za-z0-9]?)+' }],
+      features: ['ts', 'no-babel', 'no-ts-old'],
+      errors: [
+        {
+          messageId: 'patternMismatch',
+          data: {
+            propName: 'enabled',
+            pattern: '^(is|has)[A-Z]([A-Za-z0-9]?)+',
+          },
+        },
+        {
+          messageId: 'patternMismatch',
+          data: {
+            propName: 'semi',
+            pattern: '^(is|has)[A-Z]([A-Za-z0-9]?)+',
+          },
+        },
+      ],
+    },
+    {
+      code: `
+        type Props = {
+          enabled: boolean
+        };
+
+        const Hello = (props: Props & {
+          semi: boolean
+        }) => <div />;
       `,
       options: [{ rule: '^(is|has)[A-Z]([A-Za-z0-9]?)+' }],
       features: ['ts', 'no-babel', 'no-ts-old'],


### PR DESCRIPTION
related #3717

I think cause of bug  is no concider below case
```
type Props = {
  enabled: boolean
}
        
const Hello = (props: Props & {
  semi: boolean
}) => <div />;
```
To explain in detail, if the type is not `TSTypeReference` (literal type, etc.), a reference error appears to have occurred because there is no typeName property.

Therefore, if it is not the corresponding type, the type has been modified to be used as is rather than taken from objectTypeAnnotations.