### PR TITLE
Add JSDoc type annotations

### DIFF
--- a/lib/rules/boolean-prop-naming.js
+++ b/lib/rules/boolean-prop-naming.js
@@ -22,6 +22,7 @@ const messages = {
   patternMismatch: 'Prop name `{{propName}}` doesn’t match rule `{{pattern}}`',
 };
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {

--- a/lib/rules/default-props-match-prop-types.js
+++ b/lib/rules/default-props-match-prop-types.js
@@ -21,6 +21,7 @@ const messages = {
   defaultHasNoType: 'defaultProp "{{name}}" has no corresponding propTypes declaration.',
 };
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {

--- a/lib/rules/destructuring-assignment.js
+++ b/lib/rules/destructuring-assignment.js
@@ -53,6 +53,7 @@ const messages = {
   destructureInSignature: 'Must destructure props in the function signature.',
 };
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {

--- a/lib/rules/display-name.js
+++ b/lib/rules/display-name.js
@@ -27,6 +27,7 @@ const messages = {
   noContextDisplayName: 'Context definition is missing display name',
 };
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {

--- a/lib/rules/forbid-component-props.js
+++ b/lib/rules/forbid-component-props.js
@@ -22,6 +22,7 @@ const messages = {
   propIsForbidden: 'Prop "{{prop}}" is forbidden on Components',
 };
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {

--- a/lib/rules/forbid-dom-props.js
+++ b/lib/rules/forbid-dom-props.js
@@ -37,6 +37,7 @@ const messages = {
   propIsForbidden: 'Prop "{{prop}}" is forbidden on DOM Nodes',
 };
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {

--- a/lib/rules/function-component-definition.js
+++ b/lib/rules/function-component-definition.js
@@ -113,6 +113,7 @@ const messages = {
   'arrow-function': 'Function component is not an arrow function',
 };
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {

--- a/lib/rules/iframe-missing-sandbox.js
+++ b/lib/rules/iframe-missing-sandbox.js
@@ -109,6 +109,7 @@ function checkProps(context, node) {
   }
 }
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {

--- a/lib/rules/jsx-boolean-value.js
+++ b/lib/rules/jsx-boolean-value.js
@@ -54,6 +54,7 @@ const messages = {
   omitPropAndBoolean: 'Value must be omitted for `false` attribute: `{{propName}}`',
 };
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {

--- a/lib/rules/jsx-child-element-spacing.js
+++ b/lib/rules/jsx-child-element-spacing.js
@@ -44,6 +44,7 @@ const messages = {
   spacingBeforeNext: 'Ambiguous spacing before next element {{element}}',
 };
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {

--- a/lib/rules/jsx-closing-tag-location.js
+++ b/lib/rules/jsx-closing-tag-location.js
@@ -18,6 +18,7 @@ const messages = {
   matchIndent: 'Expected closing tag to match indentation of opening.',
 };
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {

--- a/lib/rules/jsx-curly-brace-presence.js
+++ b/lib/rules/jsx-curly-brace-presence.js
@@ -36,6 +36,7 @@ const messages = {
   missingCurly: 'Need to wrap this literal in a JSX expression.',
 };
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {

--- a/lib/rules/jsx-curly-newline.js
+++ b/lib/rules/jsx-curly-newline.js
@@ -41,6 +41,7 @@ const messages = {
   unexpectedAfter: 'Unexpected newline after \'{\'.',
 };
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     type: 'layout',

--- a/lib/rules/jsx-filename-extension.js
+++ b/lib/rules/jsx-filename-extension.js
@@ -28,6 +28,7 @@ const messages = {
   extensionOnlyForJSX: 'Only files containing JSX may use the extension \'{{ext}}\'',
 };
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {

--- a/lib/rules/jsx-first-prop-new-line.js
+++ b/lib/rules/jsx-first-prop-new-line.js
@@ -17,6 +17,7 @@ const messages = {
   propOnSameLine: 'Property should be placed on the same line as the component declaration',
 };
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {

--- a/lib/rules/jsx-handler-names.js
+++ b/lib/rules/jsx-handler-names.js
@@ -17,6 +17,7 @@ const messages = {
   badPropKey: 'Prop key for {{propValue}} must begin with \'{{handlerPropPrefix}}\'',
 };
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {

--- a/lib/rules/jsx-key.js
+++ b/lib/rules/jsx-key.js
@@ -32,6 +32,7 @@ const messages = {
   nonUniqueKeys: '`key` prop must be unique',
 };
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {

--- a/lib/rules/jsx-max-depth.js
+++ b/lib/rules/jsx-max-depth.js
@@ -20,6 +20,7 @@ const messages = {
   wrongDepth: 'Expected the depth of nested jsx elements to be <= {{needed}}, but found {{found}}.',
 };
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {

--- a/lib/rules/jsx-max-props-per-line.js
+++ b/lib/rules/jsx-max-props-per-line.js
@@ -23,6 +23,7 @@ const messages = {
   newLine: 'Prop `{{prop}}` must be placed on a new line',
 };
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {

--- a/lib/rules/jsx-newline.js
+++ b/lib/rules/jsx-newline.js
@@ -23,6 +23,7 @@ function isMultilined(node) {
   return node && node.loc.start.line !== node.loc.end.line;
 }
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {

--- a/lib/rules/jsx-no-comment-textnodes.js
+++ b/lib/rules/jsx-no-comment-textnodes.js
@@ -33,6 +33,7 @@ function checkText(node, context) {
   }
 }
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {

--- a/lib/rules/jsx-no-constructed-context-values.js
+++ b/lib/rules/jsx-no-constructed-context-values.js
@@ -129,6 +129,7 @@ const messages = {
   defaultMsgFunc: 'The {{type}} passed as the value prop to the Context provider (at line {{nodeLine}}) changes every render. To fix this consider wrapping it in a useCallback hook.',
 };
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {

--- a/lib/rules/jsx-no-duplicate-props.js
+++ b/lib/rules/jsx-no-duplicate-props.js
@@ -17,6 +17,7 @@ const messages = {
   noDuplicateProps: 'No duplicate props allowed',
 };
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {

--- a/lib/rules/jsx-no-leaked-render.js
+++ b/lib/rules/jsx-no-leaked-render.js
@@ -111,6 +111,7 @@ function ruleFixer(context, fixStrategy, fixer, reportedNode, leftNode, rightNod
 /**
  * @type {import('eslint').Rule.RuleModule}
  */
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {

--- a/lib/rules/jsx-no-literals.js
+++ b/lib/rules/jsx-no-literals.js
@@ -27,6 +27,7 @@ const messages = {
   literalNotInJSXExpression: 'Missing JSX expression container around literal string: "{{text}}"',
 };
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {

--- a/lib/rules/jsx-no-script-url.js
+++ b/lib/rules/jsx-no-script-url.js
@@ -43,6 +43,7 @@ const messages = {
   noScriptURL: 'A future version of React will block javascript: URLs as a security precaution. Use event handlers instead if you can. If you need to generate unsafe HTML, try using dangerouslySetInnerHTML instead.',
 };
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {

--- a/lib/rules/jsx-no-target-blank.js
+++ b/lib/rules/jsx-no-target-blank.js
@@ -126,6 +126,7 @@ const messages = {
   noTargetBlankWithoutNoopener: 'Using target="_blank" without rel="noreferrer" or rel="noopener" (the former implies the latter and is preferred due to wider support) is a security risk: see https://mathiasbynens.github.io/rel-noopener/#recommendations',
 };
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     fixable: 'code',

--- a/lib/rules/jsx-no-undef.js
+++ b/lib/rules/jsx-no-undef.js
@@ -17,6 +17,7 @@ const messages = {
   undefined: '\'{{identifier}}\' is not defined.',
 };
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {

--- a/lib/rules/jsx-no-useless-fragment.js
+++ b/lib/rules/jsx-no-useless-fragment.js
@@ -83,6 +83,7 @@ const messages = {
   ChildOfHtmlElement: 'Passing a fragment to an HTML element is useless.',
 };
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     type: 'suggestion',

--- a/lib/rules/jsx-one-expression-per-line.js
+++ b/lib/rules/jsx-one-expression-per-line.js
@@ -21,6 +21,7 @@ const messages = {
   moveToNewLine: '`{{descriptor}}` must be placed on a new line',
 };
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {

--- a/lib/rules/jsx-pascal-case.js
+++ b/lib/rules/jsx-pascal-case.js
@@ -76,6 +76,7 @@ const messages = {
   usePascalOrSnakeCase: 'Imported JSX component {{name}} must be in PascalCase or SCREAMING_SNAKE_CASE',
 };
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {

--- a/lib/rules/jsx-props-no-multi-spaces.js
+++ b/lib/rules/jsx-props-no-multi-spaces.js
@@ -17,6 +17,7 @@ const messages = {
   onlyOneSpace: 'Expected only one space between “{{prop1}}” and “{{prop2}}”',
 };
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {

--- a/lib/rules/jsx-props-no-spreading.js
+++ b/lib/rules/jsx-props-no-spreading.js
@@ -38,6 +38,7 @@ const messages = {
   noSpreading: 'Prop spreading is forbidden',
 };
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {

--- a/lib/rules/jsx-sort-props.js
+++ b/lib/rules/jsx-sort-props.js
@@ -338,6 +338,7 @@ function reportNodeAttribute(nodeAttribute, errorType, node, context, reservedLi
   });
 }
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {

--- a/lib/rules/jsx-tag-spacing.js
+++ b/lib/rules/jsx-tag-spacing.js
@@ -255,6 +255,7 @@ const optionDefaults = {
   beforeClosing: 'allow',
 };
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {

--- a/lib/rules/jsx-uses-react.js
+++ b/lib/rules/jsx-uses-react.js
@@ -12,6 +12,7 @@ const docsUrl = require('../util/docsUrl');
 // Rule Definition
 // ------------------------------------------------------------------------------
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   // eslint-disable-next-line eslint-plugin/prefer-message-ids -- https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/issues/292
   meta: {

--- a/lib/rules/jsx-uses-vars.js
+++ b/lib/rules/jsx-uses-vars.js
@@ -14,6 +14,7 @@ const docsUrl = require('../util/docsUrl');
 const isTagNameRe = /^[a-z]/;
 const isTagName = (name) => isTagNameRe.test(name);
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   // eslint-disable-next-line eslint-plugin/prefer-message-ids -- https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/issues/292
   meta: {

--- a/lib/rules/jsx-wrap-multilines.js
+++ b/lib/rules/jsx-wrap-multilines.js
@@ -35,6 +35,7 @@ const messages = {
   parensOnNewLines: 'Parentheses around JSX should be on separate lines',
 };
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {

--- a/lib/rules/no-array-index-key.js
+++ b/lib/rules/no-array-index-key.js
@@ -41,6 +41,7 @@ const messages = {
   noArrayIndex: 'Do not use Array index in keys',
 };
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {

--- a/lib/rules/no-arrow-function-lifecycle.js
+++ b/lib/rules/no-arrow-function-lifecycle.js
@@ -32,6 +32,7 @@ const messages = {
   lifecycle: '{{propertyName}} is a React lifecycle method, and should not be an arrow function or in a class field. Use an instance method instead.',
 };
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {

--- a/lib/rules/no-danger.js
+++ b/lib/rules/no-danger.js
@@ -43,6 +43,7 @@ const messages = {
   dangerousProp: 'Dangerous property \'{{name}}\' found',
 };
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {

--- a/lib/rules/no-did-mount-set-state.js
+++ b/lib/rules/no-did-mount-set-state.js
@@ -7,4 +7,5 @@
 
 const makeNoMethodSetStateRule = require('../util/makeNoMethodSetStateRule');
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = makeNoMethodSetStateRule('componentDidMount');

--- a/lib/rules/no-did-update-set-state.js
+++ b/lib/rules/no-did-update-set-state.js
@@ -7,4 +7,5 @@
 
 const makeNoMethodSetStateRule = require('../util/makeNoMethodSetStateRule');
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = makeNoMethodSetStateRule('componentDidUpdate');

--- a/lib/rules/no-direct-mutation-state.js
+++ b/lib/rules/no-direct-mutation-state.js
@@ -21,6 +21,7 @@ const messages = {
   noDirectMutation: 'Do not mutate state directly. Use setState().',
 };
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {

--- a/lib/rules/no-multi-comp.js
+++ b/lib/rules/no-multi-comp.js
@@ -19,6 +19,7 @@ const messages = {
   onlyOneComponent: 'Declare only one React component per file',
 };
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {

--- a/lib/rules/no-namespace.js
+++ b/lib/rules/no-namespace.js
@@ -18,6 +18,7 @@ const messages = {
   noNamespace: 'React component {{name}} must not be in a namespace, as React does not support them',
 };
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {

--- a/lib/rules/no-object-type-as-default-prop.js
+++ b/lib/rules/no-object-type-as-default-prop.js
@@ -78,6 +78,7 @@ function verifyDefaultPropsDestructuring(context, properties) {
   });
 }
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {

--- a/lib/rules/no-redundant-should-component-update.js
+++ b/lib/rules/no-redundant-should-component-update.js
@@ -17,6 +17,7 @@ const messages = {
   noShouldCompUpdate: '{{component}} does not need shouldComponentUpdate when extending React.PureComponent.',
 };
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {

--- a/lib/rules/no-set-state.js
+++ b/lib/rules/no-set-state.js
@@ -19,6 +19,7 @@ const messages = {
   noSetState: 'Do not use setState',
 };
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {

--- a/lib/rules/no-string-refs.js
+++ b/lib/rules/no-string-refs.js
@@ -18,6 +18,7 @@ const messages = {
   stringInRefDeprecated: 'Using string literals in ref attributes is deprecated.',
 };
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {

--- a/lib/rules/no-this-in-sfc.js
+++ b/lib/rules/no-this-in-sfc.js
@@ -16,6 +16,7 @@ const messages = {
   noThisInSFC: 'Stateless functional components should not use `this`',
 };
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {

--- a/lib/rules/no-typos.js
+++ b/lib/rules/no-typos.js
@@ -28,6 +28,7 @@ const messages = {
   noReactBinding: '`\'react\'` imported without a local `React` binding.',
 };
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {

--- a/lib/rules/no-unescaped-entities.js
+++ b/lib/rules/no-unescaped-entities.js
@@ -35,6 +35,7 @@ const messages = {
   unescapedEntityAlts: '`{{entity}}` can be escaped with {{alts}}.',
 };
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {

--- a/lib/rules/no-unsafe.js
+++ b/lib/rules/no-unsafe.js
@@ -19,6 +19,7 @@ const messages = {
   unsafeMethod: '{{method}} is unsafe for use in async rendering. Update the component to use {{newMethod}} instead. {{details}}',
 };
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {

--- a/lib/rules/no-unstable-nested-components.js
+++ b/lib/rules/no-unstable-nested-components.js
@@ -265,6 +265,7 @@ function resolveComponentName(node) {
 // Rule Definition
 // ------------------------------------------------------------------------------
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {

--- a/lib/rules/no-unused-prop-types.js
+++ b/lib/rules/no-unused-prop-types.js
@@ -22,6 +22,7 @@ const messages = {
   unusedPropType: '\'{{name}}\' PropType is defined but prop is never used',
 };
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {

--- a/lib/rules/no-will-update-set-state.js
+++ b/lib/rules/no-will-update-set-state.js
@@ -8,6 +8,7 @@
 const makeNoMethodSetStateRule = require('../util/makeNoMethodSetStateRule');
 const testReactVersion = require('../util/version').testReactVersion;
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = makeNoMethodSetStateRule(
   'componentWillUpdate',
   (context) => testReactVersion(context, '>= 16.3.0')

--- a/lib/rules/prefer-es6-class.js
+++ b/lib/rules/prefer-es6-class.js
@@ -18,6 +18,7 @@ const messages = {
   shouldUseCreateClass: 'Component should use createClass instead of es6 class',
 };
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {

--- a/lib/rules/prefer-exact-props.js
+++ b/lib/rules/prefer-exact-props.js
@@ -20,6 +20,7 @@ const messages = {
   flow: 'Component flow props should be set with exact objects.',
 };
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {

--- a/lib/rules/prefer-read-only-props.js
+++ b/lib/rules/prefer-read-only-props.js
@@ -47,6 +47,7 @@ const messages = {
   readOnlyProp: 'Prop \'{{name}}\' should be read-only.',
 };
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {

--- a/lib/rules/prefer-stateless-function.js
+++ b/lib/rules/prefer-stateless-function.js
@@ -24,6 +24,7 @@ const messages = {
   componentShouldBePure: 'Component should be written as a pure function',
 };
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {

--- a/lib/rules/prop-types.js
+++ b/lib/rules/prop-types.js
@@ -22,6 +22,7 @@ const messages = {
   missingPropType: '\'{{name}}\' is missing in props validation',
 };
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {

--- a/lib/rules/react-in-jsx-scope.js
+++ b/lib/rules/react-in-jsx-scope.js
@@ -18,6 +18,7 @@ const messages = {
   notInScope: '\'{{name}}\' must be in scope when using JSX',
 };
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {

--- a/lib/rules/require-default-props.js
+++ b/lib/rules/require-default-props.js
@@ -24,6 +24,7 @@ const messages = {
   destructureInSignature: 'Must destructure props in the function signature to initialize an optional prop.',
 };
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {

--- a/lib/rules/require-optimization.js
+++ b/lib/rules/require-optimization.js
@@ -16,6 +16,7 @@ const messages = {
   noShouldComponentUpdate: 'Component is not optimized. Please add a shouldComponentUpdate method.',
 };
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {

--- a/lib/rules/require-render-return.js
+++ b/lib/rules/require-render-return.js
@@ -21,6 +21,7 @@ const messages = {
   noRenderReturn: 'Your render method should have a return statement',
 };
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {

--- a/lib/rules/self-closing-comp.js
+++ b/lib/rules/self-closing-comp.js
@@ -19,6 +19,7 @@ const messages = {
   notSelfClosing: 'Empty components are self-closing',
 };
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {

--- a/lib/rules/sort-comp.js
+++ b/lib/rules/sort-comp.js
@@ -86,6 +86,7 @@ const messages = {
   unsortedProps: '{{propA}} should be placed {{position}} {{propB}}',
 };
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {

--- a/lib/rules/sort-prop-types.js
+++ b/lib/rules/sort-prop-types.js
@@ -53,6 +53,7 @@ function toLowerCase(item) {
   return String(item).toLowerCase();
 }
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {

--- a/lib/rules/state-in-constructor.js
+++ b/lib/rules/state-in-constructor.js
@@ -19,6 +19,7 @@ const messages = {
   stateInitClassProp: 'State initialization should be in a class property',
 };
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {

--- a/lib/rules/static-property-placement.js
+++ b/lib/rules/static-property-placement.js
@@ -55,6 +55,7 @@ const messages = {
   declareOutsideClass: '\'{{name}}\' should be declared outside the class body.',
 };
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {


### PR DESCRIPTION
Adds JSDoc annotations to rules where type changes are unnecessary, as discussed in https://github.com/jsx-eslint/eslint-plugin-react/pull/3731#discussion_r1556778045
