### PR TITLE
Add type annotation for button-has-type rule

### DIFF
--- a/lib/rules/button-has-type.js
+++ b/lib/rules/button-has-type.js
@@ -28,6 +28,7 @@ const messages = {
   forbiddenValue: '"{{value}}" is an invalid value for button type attribute',
 };
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {
@@ -149,9 +150,11 @@ module.exports = {
         }
 
         const props = node.arguments[1].properties;
-        const typeProp = props.find((prop) => prop.key && prop.key.name === 'type');
+        const typeProp = props.find(
+          (prop) => prop.type === 'Property' && prop.key.type === 'Identifier' && prop.key.name === 'type'
+        );
 
-        if (!typeProp) {
+        if (typeProp.type !== 'Property') {
           reportMissing(node);
           return;
         }


### PR DESCRIPTION
This PR adds JSDoc type annotations to the button-has-type rule.

