### PR TITLE
[Fix] `jsx-boolean-value`: `assumeUndefinedIsFalse` with `never` must not allow explicit `true` value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,10 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 ### Fixed
 * [`prop-types`]: null-check rootNode before calling getScope ([#3762][] @crnhrv)
 * [`boolean-prop-naming`]: avoid a crash with a spread prop ([#3733][] @ljharb)
+* [`jsx-boolean-value`]: `assumeUndefinedIsFalse` with `never` must not allow explicit `true` value ([#3757][] @6uliver)
 
 [#3762]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3762
+[#3757]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3757
 [#3733]: https://github.com/jsx-eslint/eslint-plugin-react/issues/3733
 
 ## [7.34.2] - 2024.05.24

--- a/lib/rules/jsx-boolean-value.js
+++ b/lib/rules/jsx-boolean-value.js
@@ -132,7 +132,6 @@ module.exports = {
         }
         if (
           isNever(configuration, exceptions, propName)
-          && !configObject.assumeUndefinedIsFalse
           && value
           && value.type === 'JSXExpressionContainer'
           && value.expression.value === true

--- a/tests/lib/rules/jsx-boolean-value.js
+++ b/tests/lib/rules/jsx-boolean-value.js
@@ -54,6 +54,10 @@ ruleTester.run('jsx-boolean-value', rule, {
     },
     {
       code: '<App foo={false} />;',
+      options: ['never', { assumeUndefinedIsFalse: false }],
+    },
+    {
+      code: '<App foo={false} />;',
       options: ['never', { assumeUndefinedIsFalse: true, always: ['foo'] }],
     },
   ]),
@@ -137,6 +141,21 @@ ruleTester.run('jsx-boolean-value', rule, {
       errors: [
         {
           messageId: 'omitPropAndBoolean',
+          data: { propName: 'foo' },
+        },
+        {
+          messageId: 'omitPropAndBoolean',
+          data: { propName: 'bak' },
+        },
+      ],
+    },
+    {
+      code: '<App foo={true} bak={false} />;',
+      output: '<App foo  />;',
+      options: ['never', { assumeUndefinedIsFalse: true }],
+      errors: [
+        {
+          messageId: 'omitBoolean',
           data: { propName: 'foo' },
         },
         {


### PR DESCRIPTION
assumeUndefinedIsFalse should not affect the behaviour of props with true values when we have the "never" setting 