### PR TITLE
[New] support eslint v9

### DIFF
--- a/.github/workflows/node-18+.yml
+++ b/.github/workflows/node-18+.yml
@@ -26,6 +26,7 @@ jobs:
       matrix:
         node-version: ${{ fromJson(needs.matrix.outputs.latest) }}
         eslint:
+          - 9
           - 8
           - 7
           - 6

--- a/.github/workflows/node-pretest.yml
+++ b/.github/workflows/node-pretest.yml
@@ -12,8 +12,6 @@ jobs:
         name: 'nvm install lts/* && npm install'
         with:
           node-version: 'lts/*'
-        env:
-          NPM_CONFIG_LEGACY_PEER_DEPS: true
       - run: npm run pretest
 
   posttest:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 ## Unreleased
 
 ### Added
+* support eslint v9 ([#3759][] @mdjermanovic)
 * export flat configs from plugin root and fix flat config crash ([#3694][] @bradzacher @mdjermanovic)
 * add [`jsx-props-no-spread-multi`] ([#3724][] @SimonSchick)
 
+[#3759]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3759
 [#3724]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3724
 [#3694]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3694
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 [#3724]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3724
 [#3694]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3694
 
+### Fixed
+* [`no-invalid-html-attribute`]: substitute placeholders in suggestion messages ([#3759][] @mdjermanovic)
+
 ## [7.34.4] - 2024.07.13
 
 ### Fixed

--- a/lib/rules/no-invalid-html-attribute.js
+++ b/lib/rules/no-invalid-html-attribute.js
@@ -8,7 +8,6 @@
 const matchAll = require('string.prototype.matchall');
 const docsUrl = require('../util/docsUrl');
 const report = require('../util/report');
-const getMessageData = require('../util/message');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -224,6 +223,7 @@ const COMPONENT_ATTRIBUTE_MAP = new Map([
   ['rel', new Set(['link', 'a', 'area', 'form'])],
 ]);
 
+/* eslint-disable eslint-plugin/no-unused-message-ids -- false positives, these messageIds are used */
 const messages = {
   emptyIsMeaningless: 'An empty “{{attributeName}}” attribute is meaningless.',
   neverValid: '“{{reportingValue}}” is never a valid “{{attributeName}}” attribute value.',
@@ -264,15 +264,11 @@ function checkLiteralValueNode(context, attributeName, node, parentNode, parentN
     report(context, messages.onlyStrings, 'onlyStrings', {
       node,
       data,
-      suggest: [
-        Object.assign(
-          getMessageData('suggestRemoveNonString', messages.suggestRemoveNonString),
-          {
-            data,
-            fix(fixer) { return fixer.remove(parentNode); },
-          }
-        ),
-      ],
+      suggest: [{
+        messageId: 'suggestRemoveNonString',
+        data,
+        fix(fixer) { return fixer.remove(parentNode); },
+      }],
     });
     return;
   }
@@ -283,15 +279,11 @@ function checkLiteralValueNode(context, attributeName, node, parentNode, parentN
     report(context, messages.noEmpty, 'noEmpty', {
       node,
       data,
-      suggest: [
-        Object.assign(
-          getMessageData('suggestRemoveEmpty', messages.suggestRemoveEmpty),
-          {
-            data,
-            fix(fixer) { return fixer.remove(node.parent); },
-          }
-        ),
-      ],
+      suggest: [{
+        messageId: 'suggestRemoveEmpty',
+        data,
+        fix(fixer) { return fixer.remove(node.parent); },
+      }],
     });
     return;
   }
@@ -307,18 +299,16 @@ function checkLiteralValueNode(context, attributeName, node, parentNode, parentN
         reportingValue,
       };
 
+      const suggest = [{
+        messageId: 'suggestRemoveInvalid',
+        data,
+        fix(fixer) { return fixer.removeRange(singlePart.range); },
+      }];
+
       report(context, messages.neverValid, 'neverValid', {
         node,
         data,
-        suggest: [
-          Object.assign(
-            getMessageData('suggestRemoveInvalid', messages.suggestRemoveInvalid),
-            {
-              data,
-              fix(fixer) { return fixer.removeRange(singlePart.range); },
-            }
-          ),
-        ],
+        suggest,
       });
     } else if (!allowedTags.has(parentNodeName)) {
       const data = {
@@ -327,18 +317,16 @@ function checkLiteralValueNode(context, attributeName, node, parentNode, parentN
         elementName: parentNodeName,
       };
 
+      const suggest = [{
+        messageId: 'suggestRemoveInvalid',
+        data,
+        fix(fixer) { return fixer.removeRange(singlePart.range); },
+      }];
+
       report(context, messages.notValidFor, 'notValidFor', {
         node,
         data,
-        suggest: [
-          Object.assign(
-            getMessageData('suggestRemoveInvalid', messages.suggestRemoveInvalid),
-            {
-              data,
-              fix(fixer) { return fixer.removeRange(singlePart.range); },
-            }
-          ),
-        ],
+        suggest,
       });
     }
   }
@@ -375,33 +363,27 @@ function checkLiteralValueNode(context, attributeName, node, parentNode, parentN
 
   const whitespaceParts = splitIntoRangedParts(node, /(\s+)/g);
   for (const whitespacePart of whitespaceParts) {
+    const data = { attributeName };
+
     if (whitespacePart.range[0] === (node.range[0] + 1) || whitespacePart.range[1] === (node.range[1] - 1)) {
       report(context, messages.spaceDelimited, 'spaceDelimited', {
         node,
-        data: { attributeName },
-        suggest: [
-          Object.assign(
-            getMessageData('suggestRemoveWhitespaces', messages.suggestRemoveWhitespaces),
-            {
-              data: { attributeName },
-              fix(fixer) { return fixer.removeRange(whitespacePart.range); },
-            }
-          ),
-        ],
+        data,
+        suggest: [{
+          messageId: 'suggestRemoveWhitespaces',
+          data,
+          fix(fixer) { return fixer.removeRange(whitespacePart.range); },
+        }],
       });
     } else if (whitespacePart.value !== '\u0020') {
       report(context, messages.spaceDelimited, 'spaceDelimited', {
         node,
-        data: { attributeName },
-        suggest: [
-          Object.assign(
-            getMessageData('suggestRemoveWhitespaces', messages.suggestRemoveWhitespaces),
-            {
-              data: { attributeName },
-              fix(fixer) { return fixer.replaceTextRange(whitespacePart.range, '\u0020'); },
-            }
-          ),
-        ],
+        data,
+        suggest: [{
+          messageId: 'suggestRemoveWhitespaces',
+          data,
+          fix(fixer) { return fixer.replaceTextRange(whitespacePart.range, '\u0020'); },
+        }],
       });
     }
   }
@@ -426,15 +408,11 @@ function checkAttribute(context, node) {
     report(context, messages.onlyMeaningfulFor, 'onlyMeaningfulFor', {
       node: node.name,
       data,
-      suggest: [
-        Object.assign(
-          getMessageData('suggestRemoveDefault', messages.suggestRemoveDefault),
-          {
-            data,
-            fix(fixer) { return fixer.remove(node); },
-          }
-        ),
-      ],
+      suggest: [{
+        messageId: 'suggestRemoveDefault',
+        data,
+        fix(fixer) { return fixer.remove(node); },
+      }],
     });
     return;
   }
@@ -447,12 +425,11 @@ function checkAttribute(context, node) {
     report(context, messages.emptyIsMeaningless, 'emptyIsMeaningless', {
       node: node.name,
       data,
-      suggest: [
-        Object.assign(
-          getMessageData('suggestRemoveEmpty', messages.suggestRemoveEmpty),
-          { data, fix }
-        ),
-      ],
+      suggest: [{
+        messageId: 'suggestRemoveEmpty',
+        data,
+        fix,
+      }],
     });
     return;
   }
@@ -475,12 +452,11 @@ function checkAttribute(context, node) {
     report(context, messages.onlyStrings, 'onlyStrings', {
       node: node.value,
       data,
-      suggest: [
-        Object.assign(
-          getMessageData('suggestRemoveDefault', messages.suggestRemoveDefault),
-          { data, fix }
-        ),
-      ],
+      suggest: [{
+        messageId: 'suggestRemoveDefault',
+        data,
+        fix,
+      }],
     });
   } else if (node.value.expression.type === 'Identifier' && node.value.expression.name === 'undefined') {
     const data = { attributeName: attribute };
@@ -488,12 +464,11 @@ function checkAttribute(context, node) {
     report(context, messages.onlyStrings, 'onlyStrings', {
       node: node.value,
       data,
-      suggest: [
-        Object.assign(
-          getMessageData('suggestRemoveDefault', messages.suggestRemoveDefault),
-          { data, fix }
-        ),
-      ],
+      suggest: [{
+        messageId: 'suggestRemoveDefault',
+        data,
+        fix,
+      }],
     });
   }
 }
@@ -523,15 +498,11 @@ function checkPropValidValue(context, node, value, attribute) {
     report(context, messages.neverValid, 'neverValid', {
       node: value,
       data,
-      suggest: [
-        Object.assign(
-          getMessageData('suggestRemoveInvalid', messages.suggestRemoveInvalid),
-          {
-            data,
-            fix(fixer) { return fixer.replaceText(value, value.raw.replace(value.value, '')); },
-          }
-        ),
-      ],
+      suggest: [{
+        messageId: 'suggestRemoveInvalid',
+        data,
+        fix(fixer) { return fixer.replaceText(value, value.raw.replace(value.value, '')); },
+      }],
     });
   } else if (!validTagSet.has(node.arguments[0].value)) {
     report(context, messages.notValidFor, 'notValidFor', {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@typescript-eslint/parser": "^2.34.0 || ^3.10.1 || ^4.0.0 || ^5.0.0",
     "aud": "^2.0.4",
     "babel-eslint": "^8 || ^9 || ^10.1.0",
-    "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8",
+    "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-doc-generator": "^1.7.1",
     "eslint-plugin-eslint-plugin": "^2.3.0 || ^3.5.3 || ^4.0.1 || ^5.0.5",
@@ -79,7 +79,7 @@
     "typescript-eslint-parser": "^20.1.1"
   },
   "peerDependencies": {
-    "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
+    "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
   },
   "engines": {
     "node": ">=4"

--- a/tests/helpers/getRuleDefiner.js
+++ b/tests/helpers/getRuleDefiner.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const eslint = require('eslint');
+
+// `ruleTester` is a RuleTester instance
+const getRuleDefiner = (ruleTester) => (typeof Symbol !== 'undefined' && Symbol.for && ruleTester[Symbol.for('react.RuleTester.RuleDefiner')])
+    || ruleTester.linter
+    || eslint.linter
+    || eslint.Linter;
+
+module.exports = getRuleDefiner;

--- a/tests/helpers/parsers.js
+++ b/tests/helpers/parsers.js
@@ -105,7 +105,7 @@ const parsers = {
           && {
             errors: testObject.errors.map(
               (errorObject) => {
-                const nextSuggestions = errorObject.suggestions && {
+                const nextSuggestions = errorObject.suggestions && typeof errorObject.suggestions !== 'number' && {
                   suggestions: errorObject.suggestions.map((suggestion) => Object.assign({}, suggestion, {
                     output: suggestion.output + extraComment,
                   })),

--- a/tests/helpers/ruleTester.js
+++ b/tests/helpers/ruleTester.js
@@ -1,0 +1,109 @@
+'use strict';
+
+const ESLintRuleTester = require('eslint').RuleTester;
+const semver = require('semver');
+const eslintPkg = require('eslint/package.json');
+
+// `item` can be a config passed to the constructor, or a test case object/string
+function convertToFlat(item, plugins) {
+  if (typeof item === 'string') {
+    return item;
+  }
+
+  if (typeof item !== 'object' || item === null) {
+    throw new TypeError('Invalid value for "item" option. Expected an object or a string.');
+  }
+
+  const newItem = Object.assign({}, item, { languageOptions: {} });
+
+  if (newItem.parserOptions) {
+    newItem.languageOptions.parserOptions = newItem.parserOptions;
+
+    if (newItem.parserOptions.ecmaVersion) {
+      newItem.languageOptions.ecmaVersion = newItem.parserOptions.ecmaVersion;
+    }
+
+    if (newItem.parserOptions.sourceType) {
+      newItem.languageOptions.sourceType = newItem.parserOptions.sourceType;
+    }
+
+    delete newItem.parserOptions;
+  }
+
+  if (newItem.parser) {
+    newItem.languageOptions.parser = require(newItem.parser); // eslint-disable-line global-require, import/no-dynamic-require
+    delete newItem.parser;
+  }
+
+  if (newItem.globals) {
+    newItem.languageOptions.globals = newItem.globals;
+    delete newItem.globals;
+  }
+
+  if (plugins) {
+    newItem.plugins = plugins;
+  }
+
+  return newItem;
+}
+
+let RuleTester = ESLintRuleTester;
+
+if (semver.major(eslintPkg.version) >= 9) {
+  const PLUGINS = Symbol('eslint-plugin-react plugins');
+  const RULE_DEFINER = Symbol.for('react.RuleTester.RuleDefiner');
+
+  RuleTester = class extends ESLintRuleTester {
+    constructor(config) {
+      if ((typeof config !== 'object' && typeof config !== 'undefined') || config === null) {
+        throw new TypeError('Invalid value for "config" option. Expected an object or undefined.');
+      }
+
+      const newConfig = convertToFlat(config || {});
+
+      if (!newConfig.languageOptions.ecmaVersion) {
+        newConfig.languageOptions.ecmaVersion = 5; // old default
+      }
+
+      if (!newConfig.languageOptions.sourceType) {
+        newConfig.languageOptions.sourceType = 'script'; // old default
+      }
+
+      super(newConfig);
+
+      this[RULE_DEFINER] = {
+        defineRule: (ruleId, rule) => {
+          if (!this[PLUGINS]) {
+            this[PLUGINS] = {};
+          }
+
+          const ruleIdSplit = ruleId.split('/');
+
+          if (ruleIdSplit.length !== 2) {
+            throw new Error('ruleId should be in the format: plugin-name/rule-name');
+          }
+
+          const pluginName = ruleIdSplit[0];
+          const ruleName = ruleIdSplit[1];
+
+          if (!this[PLUGINS][pluginName]) {
+            this[PLUGINS][pluginName] = { rules: {} };
+          }
+
+          this[PLUGINS][pluginName].rules[ruleName] = rule;
+        },
+      };
+    }
+
+    run(ruleName, rule, tests) {
+      const newTests = {
+        valid: tests.valid.map((test) => convertToFlat(test, this[PLUGINS])),
+        invalid: tests.invalid.map((test) => convertToFlat(test, this[PLUGINS])),
+      };
+
+      super.run(ruleName, rule, newTests);
+    }
+  };
+}
+
+module.exports = RuleTester;

--- a/tests/lib/rules/boolean-prop-naming.js
+++ b/tests/lib/rules/boolean-prop-naming.js
@@ -9,7 +9,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/boolean-prop-naming');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/button-has-type.js
+++ b/tests/lib/rules/button-has-type.js
@@ -9,7 +9,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/button-has-type');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/checked-requires-onchange-or-readonly.js
+++ b/tests/lib/rules/checked-requires-onchange-or-readonly.js
@@ -5,7 +5,7 @@
 
 'use strict';
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/checked-requires-onchange-or-readonly');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/default-props-match-prop-types.js
+++ b/tests/lib/rules/default-props-match-prop-types.js
@@ -10,7 +10,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/default-props-match-prop-types');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/destructuring-assignment.js
+++ b/tests/lib/rules/destructuring-assignment.js
@@ -375,18 +375,6 @@ ruleTester.run('destructuring-assignment', rule, {
         import { useContext } from 'react';
 
         const MyComponent = (props) => {
-          const {foo} = useContext(aContext);
-          return <div>{foo}</div>
-        };
-      `,
-      options: ['always'],
-      settings: { react: { version: '16.9.0' } },
-    },
-    {
-      code: `
-        import { useContext } from 'react';
-
-        const MyComponent = (props) => {
           const foo = useContext(aContext);
           return <div>{foo.test}</div>
         };

--- a/tests/lib/rules/destructuring-assignment.js
+++ b/tests/lib/rules/destructuring-assignment.js
@@ -4,9 +4,9 @@
 
 'use strict';
 
-const RuleTester = require('eslint').RuleTester;
 const semver = require('semver');
 const eslintPkg = require('eslint/package.json');
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/destructuring-assignment');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/display-name.js
+++ b/tests/lib/rules/display-name.js
@@ -9,7 +9,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/display-name');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/display-name.js
+++ b/tests/lib/rules/display-name.js
@@ -371,39 +371,6 @@ ruleTester.run('display-name', rule, {
     },
     {
       code: `
-        import React, {createElement} from "react";
-        const SomeComponent = (props) => {
-          const {foo, bar} = props;
-          return someComponentFactory({
-            onClick: () => foo(bar("x"))
-          });
-        };
-      `,
-    },
-    {
-      code: `
-        import React, {Component} from "react";
-        function someDecorator(ComposedComponent) {
-          return class MyDecorator extends Component {
-            render() {return <ComposedComponent {...this.props} />;}
-          };
-        }
-        module.exports = someDecorator;
-      `,
-    },
-    {
-      code: `
-        import React, {Component} from "react";
-        function someDecorator(ComposedComponent) {
-          return class MyDecorator extends Component {
-            render() {return <ComposedComponent {...this.props} />;}
-          };
-        }
-        module.exports = someDecorator;
-      `,
-    },
-    {
-      code: `
         const element = (
           <Media query={query} render={() => {
             renderWasCalled = true

--- a/tests/lib/rules/forbid-component-props.js
+++ b/tests/lib/rules/forbid-component-props.js
@@ -8,7 +8,7 @@
 // Requirements
 // -----------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/forbid-component-props');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/forbid-component-props.js
+++ b/tests/lib/rules/forbid-component-props.js
@@ -168,21 +168,6 @@ ruleTester.run('forbid-component-props', rule, {
     },
     {
       code: `
-        const item = (<Foo className="foo" />);
-      `,
-      options: [
-        {
-          forbid: [
-            {
-              propName: 'className',
-              disallowedFor: ['ReactModal'],
-            },
-          ],
-        },
-      ],
-    },
-    {
-      code: `
         <fbt:param name="Total number of files" number={true} />
       `,
       features: ['jsx namespace'],

--- a/tests/lib/rules/forbid-dom-props.js
+++ b/tests/lib/rules/forbid-dom-props.js
@@ -8,7 +8,7 @@
 // Requirements
 // -----------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/forbid-dom-props');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/forbid-elements.js
+++ b/tests/lib/rules/forbid-elements.js
@@ -8,7 +8,7 @@
 // Requirements
 // -----------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/forbid-elements');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/forbid-foreign-prop-types.js
+++ b/tests/lib/rules/forbid-foreign-prop-types.js
@@ -8,7 +8,7 @@
 // Requirements
 // -----------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/forbid-foreign-prop-types');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/forbid-prop-types.js
+++ b/tests/lib/rules/forbid-prop-types.js
@@ -10,7 +10,7 @@
 
 const babelEslintVersion = require('babel-eslint/package.json').version;
 const semver = require('semver');
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 
 const rule = require('../../../lib/rules/forbid-prop-types');
 

--- a/tests/lib/rules/function-component-definition.js
+++ b/tests/lib/rules/function-component-definition.js
@@ -9,7 +9,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/function-component-definition');
 
 const parserOptions = {

--- a/tests/lib/rules/hook-use-state.js
+++ b/tests/lib/rules/hook-use-state.js
@@ -9,7 +9,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/hook-use-state');
 const parsers = require('../../helpers/parsers');
 

--- a/tests/lib/rules/hook-use-state.js
+++ b/tests/lib/rules/hook-use-state.js
@@ -311,6 +311,7 @@ const tests = {
           message: 'useState call is not destructured into value + setter pair',
           suggestions: [
             {
+              messageId: 'suggestPair',
               output: `
         import { useState } from 'react'
         function useColor() {
@@ -334,7 +335,7 @@ const tests = {
           message: 'useState call is not destructured into value + setter pair',
           suggestions: [
             {
-              desc: 'Replace useState call with useMemo',
+              messageId: 'suggestMemo',
               output: `
         import { useState, useMemo } from 'react'
         function useColor(initialColor) {
@@ -343,7 +344,7 @@ const tests = {
       `,
             },
             {
-              desc: 'Destructure useState call into value + setter pair',
+              messageId: 'suggestPair',
               output: `
         import { useState } from 'react'
         function useColor(initialColor) {
@@ -366,7 +367,7 @@ const tests = {
         message: 'useState call is not destructured into value + setter pair',
         suggestions: [
           {
-            desc: 'Replace useState call with useMemo',
+            messageId: 'suggestMemo',
             output: `
         import { useState, useMemo as useMemoAlternative } from 'react'
         function useColor(initialColor) {
@@ -375,7 +376,7 @@ const tests = {
       `,
           },
           {
-            desc: 'Destructure useState call into value + setter pair',
+            messageId: 'suggestPair',
             output: `
         import { useState, useMemo as useMemoAlternative } from 'react'
         function useColor(initialColor) {
@@ -398,7 +399,7 @@ const tests = {
           message: 'useState call is not destructured into value + setter pair',
           suggestions: [
             {
-              desc: 'Replace useState call with useMemo',
+              messageId: 'suggestMemo',
               output: `
         import React from 'react'
         function useColor(initialColor) {
@@ -407,7 +408,7 @@ const tests = {
       `,
             },
             {
-              desc: 'Destructure useState call into value + setter pair',
+              messageId: 'suggestPair',
               output: `
         import React from 'react'
         function useColor(initialColor) {
@@ -432,6 +433,7 @@ const tests = {
           message: 'useState call is not destructured into value + setter pair',
           suggestions: [
             {
+              messageId: 'suggestPair',
               output: `
         import { useState } from 'react'
         function useColor() {
@@ -457,6 +459,7 @@ const tests = {
           message: 'useState call is not destructured into value + setter pair',
           suggestions: [
             {
+              messageId: 'suggestPair',
               output: `
         import { useState } from 'react'
         function useColor() {
@@ -486,6 +489,7 @@ const tests = {
           message: 'useState call is not destructured into value + setter pair',
           suggestions: [
             {
+              messageId: 'suggestPair',
               output: `
         import { useState } from 'react'
         const [color, setColor] = useState()
@@ -505,6 +509,7 @@ const tests = {
           message: 'useState call is not destructured into value + setter pair',
           suggestions: [
             {
+              messageId: 'suggestPair',
               output: `
         import { useState } from 'react'
         const [color, setColor] = useState()
@@ -561,6 +566,7 @@ const tests = {
           message: 'useState call is not destructured into value + setter pair',
           suggestions: [
             {
+              messageId: 'suggestPair',
               output: `
         import { useState } from 'react'
         const [color, setColor] = useState<string>()
@@ -584,6 +590,7 @@ const tests = {
           message: 'useState call is not destructured into value + setter pair',
           suggestions: [
             {
+              messageId: 'suggestPair',
               output: `
         import { useState } from 'react'
         function useColor() {
@@ -610,6 +617,7 @@ const tests = {
           message: 'useState call is not destructured into value + setter pair',
           suggestions: [
             {
+              messageId: 'suggestPair',
               output: `
         import React from 'react'
         function useColor() {

--- a/tests/lib/rules/iframe-missing-sandbox.js
+++ b/tests/lib/rules/iframe-missing-sandbox.js
@@ -8,7 +8,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/iframe-missing-sandbox');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/jsx-boolean-value.js
+++ b/tests/lib/rules/jsx-boolean-value.js
@@ -9,7 +9,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/jsx-boolean-value');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/jsx-child-element-spacing.js
+++ b/tests/lib/rules/jsx-child-element-spacing.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/jsx-child-element-spacing');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/jsx-closing-bracket-location.js
+++ b/tests/lib/rules/jsx-closing-bracket-location.js
@@ -9,7 +9,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/jsx-closing-bracket-location');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/jsx-closing-tag-location.js
+++ b/tests/lib/rules/jsx-closing-tag-location.js
@@ -9,7 +9,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/jsx-closing-tag-location');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/jsx-curly-brace-presence.js
+++ b/tests/lib/rules/jsx-curly-brace-presence.js
@@ -658,12 +658,6 @@ ruleTester.run('jsx-curly-brace-presence', rule, {
       errors: [{ messageId: 'missingCurly' }],
     },
     {
-      code: `<MyComponent prop="foo 'bar'">foo</MyComponent>`,
-      output: `<MyComponent prop={"foo 'bar'"}>foo</MyComponent>`,
-      options: [{ props: 'always' }],
-      errors: [{ messageId: 'missingCurly' }],
-    },
-    {
       code: '<MyComponent>foo bar </MyComponent>',
       output: `<MyComponent>{"foo bar "}</MyComponent>`,
       options: [{ children: 'always' }],

--- a/tests/lib/rules/jsx-curly-brace-presence.js
+++ b/tests/lib/rules/jsx-curly-brace-presence.js
@@ -11,9 +11,9 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
 const semver = require('semver');
 const eslintPkg = require('eslint/package.json');
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/jsx-curly-brace-presence');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/jsx-curly-newline.js
+++ b/tests/lib/rules/jsx-curly-newline.js
@@ -8,7 +8,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/jsx-curly-newline');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/jsx-curly-spacing.js
+++ b/tests/lib/rules/jsx-curly-spacing.js
@@ -762,14 +762,6 @@ ruleTester.run('jsx-curly-spacing', rule, {
         ...bar
         } />;
       `,
-      options: ['always'],
-    },
-    {
-      code: `
-        <App {
-        ...bar
-        } />;
-      `,
       options: ['never'],
     },
     {

--- a/tests/lib/rules/jsx-curly-spacing.js
+++ b/tests/lib/rules/jsx-curly-spacing.js
@@ -10,7 +10,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/jsx-curly-spacing');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/jsx-equals-spacing.js
+++ b/tests/lib/rules/jsx-equals-spacing.js
@@ -9,7 +9,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/jsx-equals-spacing');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/jsx-filename-extension.js
+++ b/tests/lib/rules/jsx-filename-extension.js
@@ -9,7 +9,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/jsx-filename-extension');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/jsx-first-prop-new-line.js
+++ b/tests/lib/rules/jsx-first-prop-new-line.js
@@ -9,7 +9,7 @@
 // Requirements
 // -----------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/jsx-first-prop-new-line');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/jsx-fragments.js
+++ b/tests/lib/rules/jsx-fragments.js
@@ -9,7 +9,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/jsx-fragments');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/jsx-handler-names.js
+++ b/tests/lib/rules/jsx-handler-names.js
@@ -265,7 +265,7 @@ ruleTester.run('jsx-handler-names', rule, {
       ],
     },
     {
-      code: '<TestComponent only={this.handleChange} />',
+      code: '<TestComponent2 only={this.handleChange} />',
       errors: [
         {
           messageId: 'badPropKey',

--- a/tests/lib/rules/jsx-handler-names.js
+++ b/tests/lib/rules/jsx-handler-names.js
@@ -9,7 +9,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/jsx-handler-names');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/jsx-indent-props.js
+++ b/tests/lib/rules/jsx-indent-props.js
@@ -9,7 +9,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/jsx-indent-props');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/jsx-indent.js
+++ b/tests/lib/rules/jsx-indent.js
@@ -9,9 +9,9 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
 const semver = require('semver');
 const eslintVersion = require('eslint/package.json').version;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/jsx-indent');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/jsx-key.js
+++ b/tests/lib/rules/jsx-key.js
@@ -9,7 +9,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/jsx-key');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/jsx-max-depth.js
+++ b/tests/lib/rules/jsx-max-depth.js
@@ -9,7 +9,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/jsx-max-depth');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/jsx-max-props-per-line.js
+++ b/tests/lib/rules/jsx-max-props-per-line.js
@@ -9,7 +9,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/jsx-max-props-per-line');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/jsx-newline.js
+++ b/tests/lib/rules/jsx-newline.js
@@ -10,7 +10,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/jsx-newline');
 const parsers = require('../../helpers/parsers');
 

--- a/tests/lib/rules/jsx-no-bind.js
+++ b/tests/lib/rules/jsx-no-bind.js
@@ -10,7 +10,7 @@
 // Requirements
 // -----------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/jsx-no-bind');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/jsx-no-comment-textnodes.js
+++ b/tests/lib/rules/jsx-no-comment-textnodes.js
@@ -9,7 +9,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/jsx-no-comment-textnodes');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/jsx-no-constructed-context-values.js
+++ b/tests/lib/rules/jsx-no-constructed-context-values.js
@@ -10,7 +10,7 @@
 // Requirements
 // -----------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/jsx-no-constructed-context-values');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/jsx-no-duplicate-props.js
+++ b/tests/lib/rules/jsx-no-duplicate-props.js
@@ -9,7 +9,7 @@
 // Requirements
 // -----------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/jsx-no-duplicate-props');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/jsx-no-leaked-render.js
+++ b/tests/lib/rules/jsx-no-leaked-render.js
@@ -126,14 +126,6 @@ ruleTester.run('jsx-no-leaked-render', rule, {
       `,
       options: [{ validStrategies: ['coerce', 'ternary'] }],
     },
-    {
-      code: `
-        const Component = ({ elements, count }) => {
-          return <div>{!!count && <List elements={elements}/>}</div>
-        }
-      `,
-      options: [{ validStrategies: ['coerce'] }],
-    },
 
     // Fixes for:
     // - https://github.com/jsx-eslint/eslint-plugin-react/issues/3292

--- a/tests/lib/rules/jsx-no-leaked-render.js
+++ b/tests/lib/rules/jsx-no-leaked-render.js
@@ -11,7 +11,7 @@
 
 const semver = require('semver');
 const eslintPkg = require('eslint/package.json');
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/jsx-no-leaked-render');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/jsx-no-literals.js
+++ b/tests/lib/rules/jsx-no-literals.js
@@ -10,7 +10,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/jsx-no-literals');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/jsx-no-script-url.js
+++ b/tests/lib/rules/jsx-no-script-url.js
@@ -9,7 +9,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/jsx-no-script-url');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/jsx-no-target-blank.js
+++ b/tests/lib/rules/jsx-no-target-blank.js
@@ -9,7 +9,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/jsx-no-target-blank');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/jsx-no-undef.js
+++ b/tests/lib/rules/jsx-no-undef.js
@@ -9,10 +9,12 @@
 // Requirements
 // -----------------------------------------------------------------------------
 
-const eslint = require('eslint');
+const semver = require('semver');
+const eslintPkg = require('eslint/package.json');
+const RuleTester = require('../../helpers/ruleTester');
+const getRuleDefiner = require('../../helpers/getRuleDefiner');
+const getESLintCoreRule = require('../../helpers/getESLintCoreRule');
 const rule = require('../../../lib/rules/jsx-no-undef');
-
-const RuleTester = eslint.RuleTester;
 
 const parsers = require('../../helpers/parsers');
 
@@ -29,8 +31,12 @@ const parserOptions = {
 // -----------------------------------------------------------------------------
 
 const ruleTester = new RuleTester({ parserOptions });
-const linter = ruleTester.linter || eslint.linter || eslint.Linter;
-linter.defineRule('no-undef', require('../../helpers/getESLintCoreRule')('no-undef'));
+
+// In ESLint >= 9, it isn't possible to redefine a core rule, but it isn't necessary anyway since the core rules are certainly already available in the RuleTester/Linter
+if (semver.major(eslintPkg.version) < 9) {
+  const ruleDefiner = getRuleDefiner(ruleTester);
+  ruleDefiner.defineRule('no-undef', getESLintCoreRule('no-undef'));
+}
 
 ruleTester.run('jsx-no-undef', rule, {
   valid: parsers.all([

--- a/tests/lib/rules/jsx-no-useless-fragment.js
+++ b/tests/lib/rules/jsx-no-useless-fragment.js
@@ -8,7 +8,7 @@
 // Requirements
 // -----------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/jsx-no-useless-fragment');
 const parsers = require('../../helpers/parsers');
 

--- a/tests/lib/rules/jsx-one-expression-per-line.js
+++ b/tests/lib/rules/jsx-one-expression-per-line.js
@@ -951,26 +951,6 @@ foo
       code: `
         <App>
           <Foo></
-        Foo></App>
-      `,
-      output: `
-        <App>
-          <Foo></
-        Foo>
-</App>
-      `,
-      errors: [
-        {
-          messageId: 'moveToNewLine',
-          data: { descriptor: 'Foo' },
-        },
-      ],
-      parserOptions,
-    },
-    {
-      code: `
-        <App>
-          <Foo></
         Foo><Bar />
         </App>
       `,

--- a/tests/lib/rules/jsx-one-expression-per-line.js
+++ b/tests/lib/rules/jsx-one-expression-per-line.js
@@ -9,7 +9,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/jsx-one-expression-per-line');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/jsx-pascal-case.js
+++ b/tests/lib/rules/jsx-pascal-case.js
@@ -9,7 +9,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/jsx-pascal-case');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/jsx-props-no-multi-spaces.js
+++ b/tests/lib/rules/jsx-props-no-multi-spaces.js
@@ -9,9 +9,9 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
 const semver = require('semver');
 const eslintPkg = require('eslint/package.json');
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/jsx-props-no-multi-spaces');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/jsx-props-no-spread-multi.js
+++ b/tests/lib/rules/jsx-props-no-spread-multi.js
@@ -8,7 +8,7 @@
 // Requirements
 // -----------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/jsx-props-no-spread-multi');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/jsx-props-no-spreading.js
+++ b/tests/lib/rules/jsx-props-no-spreading.js
@@ -8,7 +8,7 @@
 // Requirements
 // -----------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/jsx-props-no-spreading');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/jsx-sort-default-props.js
+++ b/tests/lib/rules/jsx-sort-default-props.js
@@ -11,7 +11,7 @@
 
 const babelEslintVersion = require('babel-eslint/package.json').version;
 const semver = require('semver');
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 
 const rule = require('../../../lib/rules/jsx-sort-default-props');
 

--- a/tests/lib/rules/jsx-sort-props.js
+++ b/tests/lib/rules/jsx-sort-props.js
@@ -9,9 +9,9 @@
 // Requirements
 // -----------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
 const semver = require('semver');
 const eslintPkg = require('eslint/package.json');
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/jsx-sort-props');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/jsx-space-before-closing.js
+++ b/tests/lib/rules/jsx-space-before-closing.js
@@ -9,7 +9,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/jsx-space-before-closing');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/jsx-tag-spacing.js
+++ b/tests/lib/rules/jsx-tag-spacing.js
@@ -9,7 +9,7 @@
 // Requirements
 // -----------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/jsx-tag-spacing');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/jsx-uses-react.js
+++ b/tests/lib/rules/jsx-uses-react.js
@@ -12,7 +12,7 @@
 const eslint = require('eslint');
 const rule = require('../../helpers/getESLintCoreRule')('no-unused-vars');
 
-const RuleTester = eslint.RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 
 const parsers = require('../../helpers/parsers');
 
@@ -35,50 +35,50 @@ const settings = {
 // -----------------------------------------------------------------------------
 
 const ruleTester = new RuleTester({ parserOptions });
-const linter = ruleTester.linter || eslint.linter || eslint.Linter;
-linter.defineRule('jsx-uses-react', require('../../../lib/rules/jsx-uses-react'));
+const ruleDefiner = ruleTester[Symbol.for('react.RuleTester.RuleDefiner')] || ruleTester.linter || eslint.linter || eslint.Linter;
+ruleDefiner.defineRule('react/jsx-uses-react', require('../../../lib/rules/jsx-uses-react'));
 
 ruleTester.run('no-unused-vars', rule, {
   valid: parsers.all([
-    { code: '/*eslint jsx-uses-react:1*/ var React; <div />;' },
-    { code: '/*eslint jsx-uses-react:1*/ var React; (function () { <div /> })();' },
-    { code: '/*eslint jsx-uses-react:1*/ /** @jsx Foo */ var Foo; <div />;' },
+    { code: '/*eslint react/jsx-uses-react:1*/ var React; <div />;' },
+    { code: '/*eslint react/jsx-uses-react:1*/ var React; (function () { <div /> })();' },
+    { code: '/*eslint react/jsx-uses-react:1*/ /** @jsx Foo */ var Foo; <div />;' },
     {
-      code: '/*eslint jsx-uses-react:1*/ var Foo; <div />;',
+      code: '/*eslint react/jsx-uses-react:1*/ var Foo; <div />;',
       settings,
     },
     {
-      code: '/*eslint jsx-uses-react:1*/ var Frag; <></>;',
+      code: '/*eslint react/jsx-uses-react:1*/ var Frag; <></>;',
       settings: { react: { fragment: 'Frag' } },
       features: ['fragment'],
     },
     {
-      code: '/*eslint jsx-uses-react:1*/ var React; <></>;',
+      code: '/*eslint react/jsx-uses-react:1*/ var React; <></>;',
       features: ['fragment', 'no-ts-old'], // TODO: FIXME: fix for typescript-eslint
     },
   ].map(parsers.disableNewTS)),
   invalid: parsers.all([
     {
-      code: '/*eslint jsx-uses-react:1*/ var React;',
+      code: '/*eslint react/jsx-uses-react:1*/ var React;',
       errors: [{ message: '\'React\' is defined but never used.' }],
     },
     {
-      code: '/*eslint jsx-uses-react:1*/ /** @jsx Foo */ var React; <div />;',
+      code: '/*eslint react/jsx-uses-react:1*/ /** @jsx Foo */ var React; <div />;',
       errors: [{ message: '\'React\' is defined but never used.' }],
     },
     {
-      code: '/*eslint jsx-uses-react:1*/ var React; <div />;',
+      code: '/*eslint react/jsx-uses-react:1*/ var React; <div />;',
       errors: [{ message: '\'React\' is defined but never used.' }],
       settings,
     },
     {
-      code: '/*eslint jsx-uses-react:1*/ var Frag; <></>;',
+      code: '/*eslint react/jsx-uses-react:1*/ var Frag; <></>;',
       errors: [{ message: '\'Frag\' is defined but never used.' }],
       features: ['fragment'],
       settings: { react: { fragment: 'Fragment' } },
     },
     {
-      code: '/*eslint jsx-uses-react:1*/ var React; <></>;',
+      code: '/*eslint react/jsx-uses-react:1*/ var React; <></>;',
       features: ['fragment'],
       errors: [{ message: '\'React\' is defined but never used.' }],
       settings,

--- a/tests/lib/rules/jsx-uses-react.js
+++ b/tests/lib/rules/jsx-uses-react.js
@@ -9,10 +9,10 @@
 // Requirements
 // -----------------------------------------------------------------------------
 
-const eslint = require('eslint');
 const rule = require('../../helpers/getESLintCoreRule')('no-unused-vars');
 
 const RuleTester = require('../../helpers/ruleTester');
+const getRuleDefiner = require('../../helpers/getRuleDefiner');
 
 const parsers = require('../../helpers/parsers');
 
@@ -35,7 +35,7 @@ const settings = {
 // -----------------------------------------------------------------------------
 
 const ruleTester = new RuleTester({ parserOptions });
-const ruleDefiner = ruleTester[Symbol.for('react.RuleTester.RuleDefiner')] || ruleTester.linter || eslint.linter || eslint.Linter;
+const ruleDefiner = getRuleDefiner(ruleTester);
 ruleDefiner.defineRule('react/jsx-uses-react', require('../../../lib/rules/jsx-uses-react'));
 
 ruleTester.run('no-unused-vars', rule, {

--- a/tests/lib/rules/jsx-uses-vars.js
+++ b/tests/lib/rules/jsx-uses-vars.js
@@ -13,7 +13,7 @@ const eslint = require('eslint');
 const ruleNoUnusedVars = require('../../helpers/getESLintCoreRule')('no-unused-vars');
 const rulePreferConst = require('../../helpers/getESLintCoreRule')('prefer-const');
 
-const RuleTester = eslint.RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 
 const parsers = require('../../helpers/parsers');
 
@@ -30,14 +30,14 @@ const parserOptions = {
 // -----------------------------------------------------------------------------
 
 const ruleTester = new RuleTester({ parserOptions });
-const linter = ruleTester.linter || eslint.linter || eslint.Linter;
-linter.defineRule('jsx-uses-vars', require('../../../lib/rules/jsx-uses-vars'));
+const ruleDefiner = ruleTester[Symbol.for('react.RuleTester.RuleDefiner')] || ruleTester.linter || eslint.linter || eslint.Linter;
+ruleDefiner.defineRule('react/jsx-uses-vars', require('../../../lib/rules/jsx-uses-vars'));
 
 ruleTester.run('no-unused-vars', ruleNoUnusedVars, {
   valid: parsers.all([
     {
       code: `
-        /* eslint jsx-uses-vars: 1 */
+        /* eslint react/jsx-uses-vars: 1 */
         function foo() {
           var App;
           var bar = React.render(<App/>);
@@ -48,21 +48,21 @@ ruleTester.run('no-unused-vars', ruleNoUnusedVars, {
     },
     {
       code: `
-        /* eslint jsx-uses-vars: 1 */
+        /* eslint react/jsx-uses-vars: 1 */
         var App;
         React.render(<App/>);
       `,
     },
     {
       code: `
-        /* eslint jsx-uses-vars: 1 */
+        /* eslint react/jsx-uses-vars: 1 */
         var a = 1;
         React.render(<img src={a} />);
       `,
     },
     {
       code: `
-        /* eslint jsx-uses-vars: 1 */
+        /* eslint react/jsx-uses-vars: 1 */
         var App;
         function f() {
           return <App />;
@@ -72,21 +72,21 @@ ruleTester.run('no-unused-vars', ruleNoUnusedVars, {
     },
     {
       code: `
-        /* eslint jsx-uses-vars: 1 */
+        /* eslint react/jsx-uses-vars: 1 */
         var App;
         <App.Hello />
       `,
     },
     {
       code: `
-        /* eslint jsx-uses-vars: 1 */
+        /* eslint react/jsx-uses-vars: 1 */
         class HelloMessage {};
         <HelloMessage />
       `,
     },
     {
       code: `
-        /* eslint jsx-uses-vars: 1 */
+        /* eslint react/jsx-uses-vars: 1 */
         class HelloMessage {
           render() {
             var HelloMessage = <div>Hello</div>;
@@ -98,7 +98,7 @@ ruleTester.run('no-unused-vars', ruleNoUnusedVars, {
     },
     {
       code: `
-        /* eslint jsx-uses-vars: 1 */
+        /* eslint react/jsx-uses-vars: 1 */
         function foo() {
           var App = { Foo: { Bar: {} } };
           var bar = React.render(<App.Foo.Bar/>);
@@ -109,7 +109,7 @@ ruleTester.run('no-unused-vars', ruleNoUnusedVars, {
     },
     {
       code: `
-        /* eslint jsx-uses-vars: 1 */
+        /* eslint react/jsx-uses-vars: 1 */
         function foo() {
           var App = { Foo: { Bar: { Baz: {} } } };
           var bar = React.render(<App.Foo.Bar.Baz/>);
@@ -120,14 +120,14 @@ ruleTester.run('no-unused-vars', ruleNoUnusedVars, {
     },
     {
       code: `
-        /* eslint jsx-uses-vars: 1 */
+        /* eslint react/jsx-uses-vars: 1 */
         var object;
         React.render(<object.Tag />);
       `,
     },
     {
       code: `
-        /* eslint jsx-uses-vars: 1 */
+        /* eslint react/jsx-uses-vars: 1 */
         var object;
         React.render(<object.tag />);
       `,
@@ -135,12 +135,12 @@ ruleTester.run('no-unused-vars', ruleNoUnusedVars, {
   ].map(parsers.disableNewTS)),
   invalid: parsers.all([
     {
-      code: '/* eslint jsx-uses-vars: 1 */ var App;',
+      code: '/* eslint react/jsx-uses-vars: 1 */ var App;',
       errors: [{ message: '\'App\' is defined but never used.' }],
     },
     {
       code: `
-        /* eslint jsx-uses-vars: 1 */
+        /* eslint react/jsx-uses-vars: 1 */
         var App;
         var unused;
         React.render(<App unused=""/>);
@@ -149,7 +149,7 @@ ruleTester.run('no-unused-vars', ruleNoUnusedVars, {
     },
     {
       code: `
-        /* eslint jsx-uses-vars: 1 */
+        /* eslint react/jsx-uses-vars: 1 */
         var App;
         var Hello;
         React.render(<App:Hello/>);
@@ -162,7 +162,7 @@ ruleTester.run('no-unused-vars', ruleNoUnusedVars, {
     },
     {
       code: `
-        /* eslint jsx-uses-vars: 1 */
+        /* eslint react/jsx-uses-vars: 1 */
         var Button;
         var Input;
         React.render(<Button.Input unused=""/>);
@@ -171,14 +171,14 @@ ruleTester.run('no-unused-vars', ruleNoUnusedVars, {
     },
     {
       code: `
-        /* eslint jsx-uses-vars: 1 */
+        /* eslint react/jsx-uses-vars: 1 */
         class unused {}
       `,
       errors: [{ message: '\'unused\' is defined but never used.' }],
     },
     {
       code: `
-        /* eslint jsx-uses-vars: 1 */
+        /* eslint react/jsx-uses-vars: 1 */
         class HelloMessage {
           render() {
             var HelloMessage = <div>Hello</div>;
@@ -195,7 +195,7 @@ ruleTester.run('no-unused-vars', ruleNoUnusedVars, {
     },
     {
       code: `
-        /* eslint jsx-uses-vars: 1 */
+        /* eslint react/jsx-uses-vars: 1 */
         import {Hello} from 'Hello';
         function Greetings() {
           const Hello = require('Hello').default;
@@ -212,7 +212,7 @@ ruleTester.run('no-unused-vars', ruleNoUnusedVars, {
     },
     {
       code: `
-        /* eslint jsx-uses-vars: 1 */
+        /* eslint react/jsx-uses-vars: 1 */
         var lowercase;
         React.render(<lowercase />);
       `,
@@ -220,7 +220,7 @@ ruleTester.run('no-unused-vars', ruleNoUnusedVars, {
     },
     {
       code: `
-        /* eslint jsx-uses-vars: 1 */
+        /* eslint react/jsx-uses-vars: 1 */
         function Greetings(div) {
           return <div />;
         }
@@ -242,26 +242,26 @@ ruleTester.run('prefer-const', rulePreferConst, {
   invalid: parsers.all([
     {
       code: `
-        /* eslint jsx-uses-vars:1 */
+        /* eslint react/jsx-uses-vars:1 */
         let App = <div />;
         <App />;
       `,
       errors: [{ message: '\'App\' is never reassigned. Use \'const\' instead.' }],
       output: `
-        /* eslint jsx-uses-vars:1 */
+        /* eslint react/jsx-uses-vars:1 */
         const App = <div />;
         <App />;
       `,
     },
     {
       code: `
-        /* eslint jsx-uses-vars:1 */
+        /* eslint react/jsx-uses-vars:1 */
         let filters = 'foo';
         <div>{filters}</div>;
       `,
       errors: [{ message: '\'filters\' is never reassigned. Use \'const\' instead.' }],
       output: `
-        /* eslint jsx-uses-vars:1 */
+        /* eslint react/jsx-uses-vars:1 */
         const filters = 'foo';
         <div>{filters}</div>;
       `,

--- a/tests/lib/rules/jsx-uses-vars.js
+++ b/tests/lib/rules/jsx-uses-vars.js
@@ -9,11 +9,11 @@
 // Requirements
 // -----------------------------------------------------------------------------
 
-const eslint = require('eslint');
 const ruleNoUnusedVars = require('../../helpers/getESLintCoreRule')('no-unused-vars');
 const rulePreferConst = require('../../helpers/getESLintCoreRule')('prefer-const');
 
 const RuleTester = require('../../helpers/ruleTester');
+const getRuleDefiner = require('../../helpers/getRuleDefiner');
 
 const parsers = require('../../helpers/parsers');
 
@@ -30,7 +30,7 @@ const parserOptions = {
 // -----------------------------------------------------------------------------
 
 const ruleTester = new RuleTester({ parserOptions });
-const ruleDefiner = ruleTester[Symbol.for('react.RuleTester.RuleDefiner')] || ruleTester.linter || eslint.linter || eslint.Linter;
+const ruleDefiner = getRuleDefiner(ruleTester);
 ruleDefiner.defineRule('react/jsx-uses-vars', require('../../../lib/rules/jsx-uses-vars'));
 
 ruleTester.run('no-unused-vars', ruleNoUnusedVars, {

--- a/tests/lib/rules/jsx-wrap-multilines.js
+++ b/tests/lib/rules/jsx-wrap-multilines.js
@@ -1394,16 +1394,6 @@ ruleTester.run('jsx-wrap-multilines', rule, {
       ],
     },
     {
-      code: DECLARATION_TERNARY_PAREN_FRAGMENT,
-      features: ['fragment'],
-      output: addNewLineSymbols(DECLARATION_TERNARY_PAREN_FRAGMENT),
-      options: [{ declaration: 'parens-new-line' }],
-      errors: [
-        { messageId: 'parensOnNewLines' },
-        { messageId: 'parensOnNewLines' },
-      ],
-    },
-    {
       code: ASSIGNMENT_TERNARY_NO_PAREN,
       output: addNewLineSymbols(ASSIGNMENT_TERNARY_PAREN),
       options: [{ assignment: 'parens-new-line' }],

--- a/tests/lib/rules/jsx-wrap-multilines.js
+++ b/tests/lib/rules/jsx-wrap-multilines.js
@@ -9,7 +9,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/jsx-wrap-multilines');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/no-access-state-in-setstate.js
+++ b/tests/lib/rules/no-access-state-in-setstate.js
@@ -9,7 +9,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const parsers = require('../../helpers/parsers');
 const rule = require('../../../lib/rules/no-access-state-in-setstate');
 

--- a/tests/lib/rules/no-adjacent-inline-elements.js
+++ b/tests/lib/rules/no-adjacent-inline-elements.js
@@ -9,7 +9,7 @@
 // Requirements
 // -----------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/no-adjacent-inline-elements');
 const parsers = require('../../helpers/parsers');
 

--- a/tests/lib/rules/no-array-index-key.js
+++ b/tests/lib/rules/no-array-index-key.js
@@ -9,7 +9,7 @@
 // Requirements
 // -----------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const parsers = require('../../helpers/parsers');
 const rule = require('../../../lib/rules/no-array-index-key');
 

--- a/tests/lib/rules/no-arrow-function-lifecycle.js
+++ b/tests/lib/rules/no-arrow-function-lifecycle.js
@@ -6,8 +6,8 @@
 'use strict';
 
 const semver = require('semver');
-const RuleTester = require('eslint').RuleTester;
 const eslintPkg = require('eslint/package.json');
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/no-arrow-function-lifecycle');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/no-children-prop.js
+++ b/tests/lib/rules/no-children-prop.js
@@ -9,7 +9,7 @@
 // Requirements
 // -----------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/no-children-prop');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/no-danger-with-children.js
+++ b/tests/lib/rules/no-danger-with-children.js
@@ -9,7 +9,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/no-danger-with-children');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/no-danger.js
+++ b/tests/lib/rules/no-danger.js
@@ -9,7 +9,7 @@
 // Requirements
 // -----------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/no-danger');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/no-deprecated.js
+++ b/tests/lib/rules/no-deprecated.js
@@ -11,7 +11,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/no-deprecated');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/no-did-mount-set-state.js
+++ b/tests/lib/rules/no-did-mount-set-state.js
@@ -9,7 +9,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/no-did-mount-set-state');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/no-did-update-set-state.js
+++ b/tests/lib/rules/no-did-update-set-state.js
@@ -9,7 +9,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/no-did-update-set-state');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/no-direct-mutation-state.js
+++ b/tests/lib/rules/no-direct-mutation-state.js
@@ -9,7 +9,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/no-direct-mutation-state');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/no-find-dom-node.js
+++ b/tests/lib/rules/no-find-dom-node.js
@@ -9,7 +9,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/no-find-dom-node');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/no-invalid-html-attribute.js
+++ b/tests/lib/rules/no-invalid-html-attribute.js
@@ -9,6 +9,8 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
+const semver = require('semver');
+const eslintPkg = require('eslint/package.json');
 const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/no-invalid-html-attribute');
 const parsers = require('../../helpers/parsers');
@@ -488,12 +490,19 @@ ruleTester.run('no-invalid-html-attribute', rule, {
             attributeName: 'rel',
             reportingValue: 1,
           },
-          // suggestions: [
-          //   {
-          //     messageId: 'suggestRemoveDefault',
-          //     output: 'React.createElement("a", { })',
-          //   },
-          // ],
+
+          // FIXME: this suggestion produces invalid code
+          // In ESLint > 9, RuleTester doesn't allow suggestions with parsing errors.
+          suggestions: semver.major(eslintPkg.version) < 9
+            ? [
+              {
+                messageId: 'suggestRemoveInvalid',
+                data: { reportingValue: '1' },
+                output: 'React.createElement("a", { rel:  })',
+              },
+            ]
+            : 1,
+
           type: 'Literal',
         },
       ],

--- a/tests/lib/rules/no-invalid-html-attribute.js
+++ b/tests/lib/rules/no-invalid-html-attribute.js
@@ -9,7 +9,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/no-invalid-html-attribute');
 const parsers = require('../../helpers/parsers');
 

--- a/tests/lib/rules/no-is-mounted.js
+++ b/tests/lib/rules/no-is-mounted.js
@@ -9,7 +9,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/no-is-mounted');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/no-multi-comp.js
+++ b/tests/lib/rules/no-multi-comp.js
@@ -9,7 +9,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/no-multi-comp');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/no-namespace.js
+++ b/tests/lib/rules/no-namespace.js
@@ -9,7 +9,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/no-namespace');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/no-object-type-as-default-prop.js
+++ b/tests/lib/rules/no-object-type-as-default-prop.js
@@ -9,7 +9,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const parsers = require('../../helpers/parsers');
 const rule = require('../../../lib/rules/no-object-type-as-default-prop');
 

--- a/tests/lib/rules/no-redundant-should-component-update.js
+++ b/tests/lib/rules/no-redundant-should-component-update.js
@@ -8,7 +8,7 @@
 // Requirements
 // -----------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/no-redundant-should-component-update');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/no-redundant-should-component-update.js
+++ b/tests/lib/rules/no-redundant-should-component-update.js
@@ -40,16 +40,6 @@ ruleTester.run('no-redundant-should-component-update', rule, {
     {
       code: `
         class Foo extends React.Component {
-          shouldComponentUpdate() {
-            return true;
-          }
-        }
-      `,
-      parserOptions,
-    },
-    {
-      code: `
-        class Foo extends React.Component {
           shouldComponentUpdate = () => {
             return true;
           }

--- a/tests/lib/rules/no-render-return-value.js
+++ b/tests/lib/rules/no-render-return-value.js
@@ -9,7 +9,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/no-render-return-value');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/no-set-state.js
+++ b/tests/lib/rules/no-set-state.js
@@ -9,7 +9,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/no-set-state');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/no-string-refs.js
+++ b/tests/lib/rules/no-string-refs.js
@@ -9,7 +9,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/no-string-refs');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/no-this-in-sfc.js
+++ b/tests/lib/rules/no-this-in-sfc.js
@@ -8,7 +8,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/no-this-in-sfc');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/no-typos.js
+++ b/tests/lib/rules/no-typos.js
@@ -11,7 +11,7 @@
 const babelEslintVersion = require('babel-eslint/package.json').version;
 const semver = require('semver');
 const version = require('eslint/package.json').version;
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 
 const rule = require('../../../lib/rules/no-typos');
 

--- a/tests/lib/rules/no-unescaped-entities.js
+++ b/tests/lib/rules/no-unescaped-entities.js
@@ -20,7 +20,7 @@ try {
   allowsInvalidJSX = semver.satisfies(require(resolve.sync('acorn-jsx/package.json', { basedir: path.dirname(require.resolve('eslint')) })).version, '< 5.2');
 } catch (e) { /**/ }
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/no-unescaped-entities');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/no-unknown-property.js
+++ b/tests/lib/rules/no-unknown-property.js
@@ -9,7 +9,7 @@
 // Requirements
 // -----------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/no-unknown-property');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/no-unsafe.js
+++ b/tests/lib/rules/no-unsafe.js
@@ -9,7 +9,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/no-unsafe');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/no-unstable-nested-components.js
+++ b/tests/lib/rules/no-unstable-nested-components.js
@@ -9,7 +9,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/no-unstable-nested-components');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/no-unused-class-component-methods.js
+++ b/tests/lib/rules/no-unused-class-component-methods.js
@@ -9,7 +9,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/no-unused-class-component-methods');
 const parsers = require('../../helpers/parsers');
 

--- a/tests/lib/rules/no-unused-prop-types.js
+++ b/tests/lib/rules/no-unused-prop-types.js
@@ -12,7 +12,7 @@
 const semver = require('semver');
 const eslintPkg = require('eslint/package.json');
 const babelEslintVersion = require('babel-eslint/package.json').version;
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 
 require('object.entries/auto'); // for node 6, eslint 5, new TS parser, `function Hello({firstname}: Props): React$Element {` cases
 

--- a/tests/lib/rules/no-unused-state.js
+++ b/tests/lib/rules/no-unused-state.js
@@ -5,8 +5,8 @@
 'use strict';
 
 const semver = require('semver');
-const RuleTester = require('eslint').RuleTester;
 const tsEslintVersion = require('@typescript-eslint/parser/package.json').version;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/no-unused-state');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/no-will-update-set-state.js
+++ b/tests/lib/rules/no-will-update-set-state.js
@@ -9,7 +9,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/no-will-update-set-state');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/prefer-es6-class.js
+++ b/tests/lib/rules/prefer-es6-class.js
@@ -9,7 +9,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/prefer-es6-class');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/prefer-exact-props.js
+++ b/tests/lib/rules/prefer-exact-props.js
@@ -8,7 +8,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/prefer-exact-props');
 const parsers = require('../../helpers/parsers');
 

--- a/tests/lib/rules/prefer-read-only-props.js
+++ b/tests/lib/rules/prefer-read-only-props.js
@@ -9,7 +9,7 @@
 // Requirements
 // -----------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/prefer-read-only-props');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/prefer-stateless-function.js
+++ b/tests/lib/rules/prefer-stateless-function.js
@@ -9,7 +9,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/prefer-stateless-function');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/prop-types.js
+++ b/tests/lib/rules/prop-types.js
@@ -12,7 +12,7 @@
 const semver = require('semver');
 const eslintPkg = require('eslint/package.json').version;
 const babelEslintVersion = require('babel-eslint/package.json').version;
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 
 const rule = require('../../../lib/rules/prop-types');
 

--- a/tests/lib/rules/prop-types.js
+++ b/tests/lib/rules/prop-types.js
@@ -1589,15 +1589,6 @@ ruleTester.run('prop-types', rule, {
       `,
     },
     {
-      // Async generator functions can't be components.
-      code: `
-        var Hello = async function* (props) {
-          yield null;
-          return <div>Hello {props.name}</div>;
-        }
-      `,
-    },
-    {
       // Flow annotations with variance
       code: `
         type Props = {
@@ -5313,27 +5304,6 @@ ruleTester.run('prop-types', rule, {
         }
         Test.propTypes = propTypes;
       `,
-      errors: [
-        {
-          messageId: 'missingPropType',
-          data: { name: 'lastname' },
-        },
-      ],
-    },
-    {
-      code: `
-        class Test extends Foo.Component {
-          render() {
-            return (
-              <div>{this.props.firstname} {this.props.lastname}</div>
-            );
-          }
-        }
-        Test.propTypes = {
-          firstname: PropTypes.string
-        };
-      `,
-      settings,
       errors: [
         {
           messageId: 'missingPropType',

--- a/tests/lib/rules/react-in-jsx-scope.js
+++ b/tests/lib/rules/react-in-jsx-scope.js
@@ -9,7 +9,7 @@
 // Requirements
 // -----------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/react-in-jsx-scope');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/react-in-jsx-scope.js
+++ b/tests/lib/rules/react-in-jsx-scope.js
@@ -44,9 +44,6 @@ ruleTester.run('react-in-jsx-scope', rule, {
     { code: 'var React; <x-gif />;' },
     { code: 'var React, App, a=1; <App attr={a} />;' },
     { code: 'var React, App, a=1; function elem() { return <App attr={a} />; }' },
-    {
-      code: 'var React, App; <App />;',
-    },
     { code: '/** @jsx Foo */ var Foo, App; <App />;' },
     { code: '/** @jsx Foo.Bar */ var Foo, App; <App />;' },
     {

--- a/tests/lib/rules/require-default-props.js
+++ b/tests/lib/rules/require-default-props.js
@@ -9,7 +9,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/require-default-props');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/require-default-props.js
+++ b/tests/lib/rules/require-default-props.js
@@ -3019,30 +3019,6 @@ ruleTester.run('require-default-props', rule, {
         },
       ],
     },
-    {
-      code: `
-        function MyStatelessComponent({ foo, bar }) {
-          return <div>{foo}{bar}</div>;
-        }
-        MyStatelessComponent.propTypes = {
-          foo: PropTypes.string,
-          bar: PropTypes.string.isRequired
-        };
-        MyStatelessComponent.propTypes.baz = React.propTypes.string;
-      `,
-      errors: [
-        {
-          messageId: 'shouldHaveDefault',
-          data: { name: 'foo' },
-          line: 6,
-        },
-        {
-          messageId: 'shouldHaveDefault',
-          data: { name: 'baz' },
-          line: 9,
-        },
-      ],
-    },
 
     {
       code: `

--- a/tests/lib/rules/require-optimization.js
+++ b/tests/lib/rules/require-optimization.js
@@ -5,7 +5,7 @@
 
 'use strict';
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/require-optimization');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/require-render-return.js
+++ b/tests/lib/rules/require-render-return.js
@@ -9,7 +9,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/require-render-return');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/self-closing-comp.js
+++ b/tests/lib/rules/self-closing-comp.js
@@ -9,7 +9,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/self-closing-comp');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/sort-comp.js
+++ b/tests/lib/rules/sort-comp.js
@@ -9,7 +9,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/sort-comp');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/sort-default-props.js
+++ b/tests/lib/rules/sort-default-props.js
@@ -11,7 +11,7 @@
 
 const babelEslintVersion = require('babel-eslint/package.json').version;
 const semver = require('semver');
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 
 const rule = require('../../../lib/rules/sort-default-props');
 

--- a/tests/lib/rules/sort-prop-types.js
+++ b/tests/lib/rules/sort-prop-types.js
@@ -11,7 +11,7 @@
 const babelEslintVersion = require('babel-eslint/package.json').version;
 const semver = require('semver');
 const eslintPkg = require('eslint/package.json');
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 
 const rule = require('../../../lib/rules/sort-prop-types');
 

--- a/tests/lib/rules/state-in-constructor.js
+++ b/tests/lib/rules/state-in-constructor.js
@@ -9,7 +9,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/state-in-constructor');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/static-property-placement.js
+++ b/tests/lib/rules/static-property-placement.js
@@ -16,7 +16,7 @@ const PROPERTY_ASSIGNMENT = 'property assignment';
 // Requirements
 // ------------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/static-property-placement');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/style-prop-object.js
+++ b/tests/lib/rules/style-prop-object.js
@@ -9,7 +9,7 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/style-prop-object');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/lib/rules/void-dom-elements-no-children.js
+++ b/tests/lib/rules/void-dom-elements-no-children.js
@@ -9,7 +9,7 @@
 // Requirements
 // -----------------------------------------------------------------------------
 
-const RuleTester = require('eslint').RuleTester;
+const RuleTester = require('../../helpers/ruleTester');
 const rule = require('../../../lib/rules/void-dom-elements-no-children');
 
 const parsers = require('../../helpers/parsers');

--- a/tests/util/Components.js
+++ b/tests/util/Components.js
@@ -2,14 +2,14 @@
 
 const assert = require('assert');
 const entries = require('object.entries');
-const eslint = require('eslint');
 const fromEntries = require('object.fromentries');
 const values = require('object.values');
 
+const RuleTester = require('../helpers/ruleTester');
 const Components = require('../../lib/util/Components');
 const parsers = require('../helpers/parsers');
 
-const ruleTester = new eslint.RuleTester({
+const ruleTester = new RuleTester({
   parserOptions: {
     ecmaVersion: 2018,
     sourceType: 'module',


### PR DESCRIPTION
Refs https://github.com/jsx-eslint/eslint-plugin-react/issues/3699

Adds utility to automatically transform tests to ESLint v9 format when ESLint v9 is used.

I have all tests still passing with ESLint v8 locally (we'll see what happens with the older versions in CI).

Around ~500 tests are failing with ESLint v9 due to new RuleTester checks. Some because of problems in tests (e.g., duplicate tests or missing some now-mandatory test case properties), some because of problems in rules (e.g., no-op options schema or unsubstituted placeholders in messages). I'll try to fix that in separate commits in this PR.

Also fixed bugs that ESLint v9 RuleTester caught in rules `jsx-closing-bracket-location` and `no-invalid-html-attribute`.