### PR TITLE
[Fix] Null check `rootNode` before calling `getScope` with it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 
 ## Unreleased
 
+### Fixed
+* [`prop-types`]: null-check rootNode before calling getScope ([#3762][] @crnhrv)
+
+[#3762]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3762
+
 ## [7.34.2] - 2024.05.24
 
 ### Fixed

--- a/lib/util/propTypes.js
+++ b/lib/util/propTypes.js
@@ -372,7 +372,8 @@ module.exports = function propTypesInstructions(context, components, utils) {
    */
   function resolveValueForIdentifierNode(node, rootNode, callback) {
     if (
-      node
+      rootNode
+      && node
       && node.type === 'Identifier'
     ) {
       const scope = getScope(context, rootNode);

--- a/tests/lib/rules/prop-types.js
+++ b/tests/lib/rules/prop-types.js
@@ -3363,6 +3363,20 @@ ruleTester.run('prop-types', rule, {
     },
     {
       code: `
+        import React from "react";
+
+        const returnTypeProp = (someProp: any) => ({ someProp });
+
+        const SomeComponent: React.FunctionComponent<
+          ReturnType<typeof returnTypeProp>
+        > = ({ someProp }) => {
+          return <div>{someProp}</div>;
+        };
+      `,
+      features: ['ts', 'no-babel'],
+    },
+    {
+      code: `
         export const EuiSuperSelectControl: <T extends string>(
           props: EuiSuperSelectControlProps<T>
         ) => ReturnType<FunctionComponent<EuiSuperSelectControlProps<T>>> = ({
@@ -7836,6 +7850,26 @@ ruleTester.run('prop-types', rule, {
         {
           messageId: 'missingPropType',
           data: { name: 'test' },
+        },
+      ],
+      features: ['ts', 'no-babel'],
+    },
+    {
+      code: `
+        import React from "react";
+
+        const returnTypeProp = (someProp: any) => ({ someProp });
+
+        const SomeComponent: React.FunctionComponent<
+          ReturnType<typeof returnTypeProp>
+        > = ({ someIncorrectProp }) => {
+          return <div>{someProp}</div>;
+        };
+      `,
+      errors: [
+        {
+          messageId: 'missingPropType',
+          data: { name: 'someIncorrectProp' },
         },
       ],
       features: ['ts', 'no-babel'],


### PR DESCRIPTION
I'm getting this error while linting some valid React/TS code after upgrading to the latest version (`7.34.2`):

<details>
<summary>Stack trace</summary>

```
Oops! Something went wrong! :(

  ESLint: 8.57.0
  
  TypeError: Missing required argument: node.
  Occurred while linting ./OptionsTable.tsx:599
  Rule: "react/display-name"
      at SourceCode.getScope (./node_modules/eslint/lib/source-code/source-code.js:773:19)
      at getScope (./node_modules/eslint-plugin-react/lib/util/eslint.js:19:23)
      at resolveValueForIdentifierNode (./node_modules/eslint-plugin-react/lib/util/propTypes.js:378:21)
      at buildReactDeclarationTypes (./node_modules/eslint-plugin-react/lib/util/propTypes.js:420:5)
      at ./node_modules/eslint-plugin-react/lib/util/propTypes.js:788:39
      at iterateProperties (./node_modules/eslint-plugin-react/lib/util/propTypes.js:71:7)
      at ./node_modules/eslint-plugin-react/lib/util/propTypes.js:773:23
      at Array.forEach (<anonymous>)
      at DeclarePropTypesForTSTypeAnnotation.convertReturnTypeToPropTypes (./node_modules/eslint-plugin-react/lib/util/propTypes.js:762:34)
      at DeclarePropTypesForTSTypeAnnotation.searchDeclarationByName (./node_modules/eslint-plugin-react/lib/util/propTypes.js:667:14)
```

</details>

I don't really understand enough about the codebase to say whether this is the correct fix, or if this really should be passing in `node` instead of `rootNode` to `getScope` or something like that. This resolves the immediate issue for me at least and seemed reasonable to check the value is valid before it tries to call something that requires it.
