### PR TITLE
[Fix] `sort-prop-types`: Check for undefined before accessing `node.typeAnnotation.typeAnnotation`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 ### Fixed
 
 * [`prop-types`]: fix `className` missing in prop validation false negative ([#3749] @akulsr0)
+* [`sort-prop-types`]: Check for undefined before accessing `node.typeAnnotation.typeAnnotation` ([#3779] @tylerlaprade)
 
+[#3779]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3779
 [#3749]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3749
 
 ## [7.34.3] - 2024.06.18

--- a/lib/rules/sort-prop-types.js
+++ b/lib/rules/sort-prop-types.js
@@ -230,7 +230,10 @@ module.exports = {
     }
 
     function handleFunctionComponent(node) {
-      const firstArg = node.params[0].typeAnnotation && node.params[0].typeAnnotation.typeAnnotation;
+      const firstArg = node.params
+        && node.params.length > 0
+        && node.params[0].typeAnnotation
+        && node.params[0].typeAnnotation.typeAnnotation;
       if (firstArg && firstArg.type === 'TSTypeReference') {
         const propType = typeAnnotations.get(firstArg.typeName.name)
           && typeAnnotations.get(firstArg.typeName.name)[0];

--- a/tests/lib/rules/sort-prop-types.js
+++ b/tests/lib/rules/sort-prop-types.js
@@ -493,6 +493,14 @@ ruleTester.run('sort-prop-types', rule, {
       `,
       features: ['types'],
       options: [{ checkTypes: false }],
+    },
+    {
+      code: `
+        function Foo() {
+          return <div />;
+        }
+      `,
+      options: [{ checkTypes: true }],
     }
   )),
   invalid: parsers.all([].concat(


### PR DESCRIPTION
Fixes the bug reported in [this comment](https://github.com/jsx-eslint/eslint-plugin-react/issues/3763#issuecomment-2215163106)