### PR TITLE
[Fix] `jsx-curly-brace-presence`: do not trigger on strings containing a quote character

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 
 ## Unreleased
 
+### Fixed
+* [`jsx-curly-brace-presence`]: do not trigger on strings containing a quote character ([#3798][] @akulsr0)
+
+[#3798]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3798
+
 ## [7.35.0] - 2024.07.19
 
 ### Added

--- a/lib/rules/jsx-curly-brace-presence.js
+++ b/lib/rules/jsx-curly-brace-presence.js
@@ -269,7 +269,7 @@ module.exports = {
           && !containsMultilineComment(expression.value)
           && !needToEscapeCharacterForJSX(expression.raw, JSXExpressionNode) && (
           jsxUtil.isJSX(JSXExpressionNode.parent)
-          || !containsQuoteCharacters(expression.value)
+          || (!containsQuoteCharacters(expression.value) || typeof expression.value === 'string')
         )
       ) {
         reportUnnecessaryCurly(JSXExpressionNode);

--- a/tests/lib/rules/jsx-curly-brace-presence.js
+++ b/tests/lib/rules/jsx-curly-brace-presence.js
@@ -934,6 +934,12 @@ ruleTester.run('jsx-curly-brace-presence', rule, {
       errors: [{ messageId: 'unnecessaryCurly' }],
       options: [{ props: 'never', children: 'never', propElementValues: 'never' }],
       features: ['no-ts'],
+    },
+    {
+      code: `<Foo bar={"'"} />`,
+      output: `<Foo bar="'" />`,
+      errors: [{ messageId: 'unnecessaryCurly' }],
+      options: [{ props: 'never', children: 'never', propElementValues: 'never' }],
     }
   )),
 });


### PR DESCRIPTION
Fixes #3795