### PR TITLE
[New] `forbid-component-props`: add `allowedForPatterns` and `disallowedForPatterns` options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 ### Added
 * add type generation ([#3830][] @voxpelli)
 * [`no-unescaped-entities`]: add suggestions ([#3831][] @StyleShit)
+* [`forbid-component-props`]: add `allowedForPatterns`/`disallowedForPatterns` options ([#3805][] @Efimenko)
 
 [#3831]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3831
 [#3830]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3830
+[#3805]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3805
 
 ## [7.36.1] - 2024.09.12
 

--- a/docs/rules/forbid-component-props.md
+++ b/docs/rules/forbid-component-props.md
@@ -55,16 +55,6 @@ custom message, and a component allowlist:
 }
 ```
 
-For glob string patterns:
-
-```js
-{
-  "propNamePattern": '**-**',
-  "allowedFor": ['div'],
-  "message": "Avoid using kebab-case except div"
-}
-```
-
 Use `disallowedFor` as an exclusion list to warn on props for specific components. `disallowedFor` must have at least one item.
 
 ```js
@@ -75,13 +65,52 @@ Use `disallowedFor` as an exclusion list to warn on props for specific component
 }
 ```
 
-For glob string patterns:
+For `propNamePattern` glob string patterns:
 
 ```js
 {
-  "propNamePattern": "**-**",
-  "disallowedFor": ["MyComponent"],
-  "message": "Avoid using kebab-case for MyComponent"
+  "propNamePattern": '**-**',
+  "allowedFor": ['div'],
+  "message": "Avoid using kebab-case except div"
+}
+```
+
+```js
+{
+  "propNamePattern": '**-**',
+  "allowedForPatterns": ["*Component"],
+  "message": "Avoid using kebab-case except components that match the `*Component` pattern"
+}
+```
+
+Use `allowedForPatterns` for glob string patterns:
+
+```js
+{
+  "propName": "someProp",
+  "allowedForPatterns": ["*Component"],
+  "message": "Avoid using `someProp` except components that match the `*Component` pattern"
+}
+```
+
+Use `disallowedForPatterns` for glob string patterns:
+
+```js
+{
+  "propName": "someProp",
+  "disallowedForPatterns": ["*Component"],
+  "message": "Avoid using `someProp` for components that match the `*Component` pattern"
+}
+```
+
+Combine several properties to cover more cases:
+
+```js
+{
+  "propName": "someProp",
+  "allowedFor": ['div'],
+  "allowedForPatterns": ["*Component"],
+  "message": "Avoid using `someProp` except `div` and components that match the `*Component` pattern"
 }
 ```
 

--- a/lib/rules/forbid-component-props.js
+++ b/lib/rules/forbid-component-props.js
@@ -52,6 +52,11 @@ module.exports = {
                     uniqueItems: true,
                     items: { type: 'string' },
                   },
+                  allowedForPatterns: {
+                    type: 'array',
+                    uniqueItems: true,
+                    items: { type: 'string' },
+                  },
                   message: { type: 'string' },
                 },
                 additionalProperties: false,
@@ -66,17 +71,30 @@ module.exports = {
                     minItems: 1,
                     items: { type: 'string' },
                   },
+                  disallowedForPatterns: {
+                    type: 'array',
+                    uniqueItems: true,
+                    minItems: 1,
+                    items: { type: 'string' },
+                  },
                   message: { type: 'string' },
                 },
-                required: ['disallowedFor'],
+                anyOf: [
+                  { required: ['disallowedFor'] },
+                  { required: ['disallowedForPatterns'] },
+                ],
                 additionalProperties: false,
               },
-
               {
                 type: 'object',
                 properties: {
                   propNamePattern: { type: 'string' },
                   allowedFor: {
+                    type: 'array',
+                    uniqueItems: true,
+                    items: { type: 'string' },
+                  },
+                  allowedForPatterns: {
                     type: 'array',
                     uniqueItems: true,
                     items: { type: 'string' },
@@ -95,9 +113,18 @@ module.exports = {
                     minItems: 1,
                     items: { type: 'string' },
                   },
+                  disallowedForPatterns: {
+                    type: 'array',
+                    uniqueItems: true,
+                    minItems: 1,
+                    items: { type: 'string' },
+                  },
                   message: { type: 'string' },
                 },
-                required: ['disallowedFor'],
+                anyOf: [
+                  { required: ['disallowedFor'] },
+                  { required: ['disallowedForPatterns'] },
+                ],
                 additionalProperties: false,
               },
             ],
@@ -114,8 +141,10 @@ module.exports = {
       const propPattern = value.propNamePattern;
       const prop = propName || propPattern;
       const options = {
-        allowList: typeof value === 'string' ? [] : (value.allowedFor || []),
-        disallowList: typeof value === 'string' ? [] : (value.disallowedFor || []),
+        allowList: [].concat(value.allowedFor || []),
+        allowPatternList: [].concat(value.allowedForPatterns || []),
+        disallowList: [].concat(value.disallowedFor || []),
+        disallowPatternList: [].concat(value.disallowedForPatterns || []),
         message: typeof value === 'string' ? null : value.message,
         isPattern: !!value.propNamePattern,
       };
@@ -140,10 +169,40 @@ module.exports = {
         return false;
       }
 
+      function checkIsTagForbiddenByAllowOptions() {
+        if (options.allowList.indexOf(tagName) !== -1) {
+          return false;
+        }
+
+        if (options.allowPatternList.length === 0) {
+          return true;
+        }
+
+        return options.allowPatternList.every(
+          (pattern) => !minimatch(tagName, pattern)
+        );
+      }
+
+      function checkIsTagForbiddenByDisallowOptions() {
+        if (options.disallowList.indexOf(tagName) !== -1) {
+          return true;
+        }
+
+        if (options.disallowPatternList.length === 0) {
+          return false;
+        }
+
+        return options.disallowPatternList.some(
+          (pattern) => minimatch(tagName, pattern)
+        );
+      }
+
+      const hasDisallowOptions = options.disallowList.length > 0 || options.disallowPatternList.length > 0;
+
       // disallowList should have a least one item (schema configuration)
-      const isTagForbidden = options.disallowList.length > 0
-        ? options.disallowList.indexOf(tagName) !== -1
-        : options.allowList.indexOf(tagName) === -1;
+      const isTagForbidden = hasDisallowOptions
+        ? checkIsTagForbiddenByDisallowOptions()
+        : checkIsTagForbiddenByAllowOptions();
 
       // if the tagName is undefined (`<this.something>`), we assume it's a forbidden element
       return typeof tagName === 'undefined' || isTagForbidden;

--- a/tests/lib/rules/forbid-component-props.js
+++ b/tests/lib/rules/forbid-component-props.js
@@ -250,6 +250,78 @@ ruleTester.run('forbid-component-props', rule, {
         },
       ],
     },
+    {
+      code: `
+        const rootElement = (
+          <Root>
+            <SomeIcon className="size-lg" />
+            <AnotherIcon className="size-lg" />
+            <SomeSvg className="size-lg" />
+            <UICard className="size-lg" />
+            <UIButton className="size-lg" />
+          </Root>
+        );
+      `,
+      options: [
+        {
+          forbid: [
+            {
+              propName: 'className',
+              allowedForPatterns: ['*Icon', '*Svg', 'UI*'],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+        const rootElement = (
+          <Root>
+            <SomeIcon className="size-lg" />
+            <AnotherIcon className="size-lg" />
+            <SomeSvg className="size-lg" />
+            <UICard className="size-lg" />
+            <UIButton className="size-lg" />
+            <ButtonLegacy className="size-lg" />
+          </Root>
+        );
+      `,
+      options: [
+        {
+          forbid: [
+            {
+              propName: 'className',
+              allowedFor: ['ButtonLegacy'],
+              allowedForPatterns: ['*Icon', '*Svg', 'UI*'],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+        const rootElement = (
+          <Root>
+            <SomeIcon className="size-lg" />
+            <AnotherIcon className="size-lg" />
+            <SomeSvg className="size-lg" />
+            <UICard className="size-lg" />
+            <UIButton className="size-lg" />
+          </Root>
+        );
+      `,
+      options: [
+        {
+          forbid: [
+            {
+              propName: 'className',
+              disallowedFor: ['Modal'],
+              disallowedForPatterns: ['*Legacy', 'Shared*'],
+            },
+          ],
+        },
+      ],
+    },
   ]),
 
   invalid: parsers.all([
@@ -675,6 +747,127 @@ ruleTester.run('forbid-component-props', rule, {
           data: { prop: 'kebab-case-prop' },
           line: 6,
           column: 18,
+          type: 'JSXAttribute',
+        },
+      ],
+    },
+    {
+      code: `
+        const rootElement = () => (
+          <Root>
+            <SomeIcon className="size-lg" />
+            <SomeSvg className="size-lg" />
+          </Root>
+        );
+      `,
+      options: [
+        {
+          forbid: [
+            {
+              propName: 'className',
+              message: 'className available only for icons',
+              allowedForPatterns: ['*Icon'],
+            },
+          ],
+        },
+      ],
+      errors: [
+        {
+          message: 'className available only for icons',
+          line: 5,
+          column: 22,
+          type: 'JSXAttribute',
+        },
+      ],
+    },
+    {
+      code: `
+        const rootElement = () => (
+          <Root>
+            <UICard style={{backgroundColor: black}}/>
+            <SomeIcon className="size-lg" />
+            <SomeSvg className="size-lg" style={{fill: currentColor}} />
+          </Root>
+        );
+      `,
+      options: [
+        {
+          forbid: [
+            {
+              propName: 'className',
+              message: 'className available only for icons',
+              allowedForPatterns: ['*Icon'],
+            },
+            {
+              propName: 'style',
+              message: 'style available only for SVGs',
+              allowedForPatterns: ['*Svg'],
+            },
+          ],
+        },
+      ],
+      errors: [
+        {
+          message: 'style available only for SVGs',
+          line: 4,
+          column: 21,
+          type: 'JSXAttribute',
+        },
+        {
+          message: 'className available only for icons',
+          line: 6,
+          column: 22,
+          type: 'JSXAttribute',
+        },
+      ],
+    },
+    {
+      code: `
+        const rootElement = (
+          <Root>
+            <SomeIcon className="size-lg" />
+            <AnotherIcon className="size-lg" />
+            <SomeSvg className="size-lg" />
+            <UICard className="size-lg" />
+            <ButtonLegacy className="size-lg" />
+          </Root>
+        );
+      `,
+      options: [
+        {
+          forbid: [
+            {
+              propName: 'className',
+              disallowedFor: ['SomeSvg'],
+              disallowedForPatterns: ['UI*', '*Icon'],
+              message: 'Avoid using className for SomeSvg and components that match the `UI*` and `*Icon` patterns',
+            },
+          ],
+        },
+      ],
+      errors: [
+        {
+          message: 'Avoid using className for SomeSvg and components that match the `UI*` and `*Icon` patterns',
+          line: 4,
+          column: 23,
+          type: 'JSXAttribute',
+        },
+        {
+          message: 'Avoid using className for SomeSvg and components that match the `UI*` and `*Icon` patterns',
+          line: 5,
+          column: 26,
+          type: 'JSXAttribute',
+        },
+        {
+          message: 'Avoid using className for SomeSvg and components that match the `UI*` and `*Icon` patterns',
+          line: 6,
+          column: 22,
+          type: 'JSXAttribute',
+        },
+        {
+          message: 'Avoid using className for SomeSvg and components that match the `UI*` and `*Icon` patterns',
+          line: 7,
+          column: 21,
           type: 'JSXAttribute',
         },
       ],


### PR DESCRIPTION
Initially, issue was described [here](https://github.com/jsx-eslint/eslint-plugin-react/issues/3686), but it was closed by [another PR](https://github.com/jsx-eslint/eslint-plugin-react/pull/3774) (although this PR implements different case).
So, this PR just reimplements `Regex` implementation with `globs` as was suggested in [one](https://github.com/jsx-eslint/eslint-plugin-react/issues/3686#issuecomment-1951461748) of the comments.