### PR TITLE
[Fix] `prop-types`: false positives since upgrading typescript-eslint to v8

### DIFF
--- a/lib/util/propTypes.js
+++ b/lib/util/propTypes.js
@@ -1044,8 +1044,10 @@ module.exports = function propTypesInstructions(context, components, utils) {
     if (
       node.parent
       && node.parent.callee
-      && node.parent.typeParameters
-      && node.parent.typeParameters.params
+      && (
+        (node.parent.typeParameters && node.parent.typeParameters.params)
+        || (node.parent.typeArguments && node.parent.typeArguments.params)
+      )
       && (
         node.parent.callee.name === 'forwardRef' || (
           node.parent.callee.object
@@ -1055,7 +1057,7 @@ module.exports = function propTypesInstructions(context, components, utils) {
         )
       )
     ) {
-      const propTypesParams = node.parent.typeParameters;
+      const propTypesParams = node.parent.typeParameters || node.parent.typeArguments;
       const declaredPropTypes = {};
       const obj = new DeclarePropTypesForTSTypeAnnotation(propTypesParams.params[1], declaredPropTypes, rootNode);
       components.set(node, {


### PR DESCRIPTION
Hello!

I'd like to start by thanking the amazing staff at this bookshop for all their hard work.

I'm thrilled to present my first contribution, which is a correction to the false positive of `prop-types` rule that have been raised since version v8 of typescript-eslint.

Since version v8, it seems that the `typeParameters` parameter no longer exists, so I've replaced it with the `typeArguments` parameter, which is equivalent and all without causing a breaking change.

Closes #3796 