### PR TITLE
[New] `jsx-no-literals`: add `elementOverrides` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 
 ### Added
 * [`no-string-refs`]: allow this.refs in > 18.3.0 ([#3807][] @henryqdineen)
+* [`jsx-no-literals`] Add `elementOverrides` option and the ability to ignore this rule on specific elements ([#3812][] @Pearce-Ropion)
 
 ### Fixed
 * [`function-component-definition`], [`boolean-prop-naming`], [`jsx-first-prop-new-line`], [`jsx-props-no-multi-spaces`], `propTypes`: use type args ([#3629][] @HenryBrown0)
@@ -20,6 +21,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 
 [#3632]: https://github.com/jsx-eslint/eslint-plugin-react/issues/3632
 
+[#3812]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3812
 [#3629]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3629
 [#3817]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3817
 [#3807]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3807

--- a/docs/rules/jsx-no-literals.md
+++ b/docs/rules/jsx-no-literals.md
@@ -34,6 +34,61 @@ The supported options are:
 - `allowedStrings` - An array of unique string values that would otherwise warn, but will be ignored.
 - `ignoreProps` (default: `false`) - When `true` the rule ignores literals used in props, wrapped or unwrapped.
 - `noAttributeStrings` (default: `false`) - Enforces no string literals used in attributes when set to `true`.
+- `elementOverrides` - An object where the keys are the element names and the values are objects with the same options as above. This allows you to specify different options for different elements.
+
+### `elementOverrides`
+
+The `elementOverrides` option allows you to specify different options for different elements. This is useful when you want to enforce different rules for different elements. For example, you may want to allow string literals in `Button` elements, but not in the rest of your application.
+
+The element name only accepts component names.
+HTML element tag names are not supported. Component names are case-sensitive and should exactly match the name of the component as it is used in the JSX.
+It can also be the name of a compound component (ie. `Modal.Button`).
+
+Specifying options creates a new context for the rule, so the rule will only apply the new options to the specified element and its children (if `applyToNestedElements` is `true` - see below).
+This means that the root rule options will not apply to the specified element.
+
+In addition to the options above (`noStrings`, `allowedStrings`, `noAttributeStrings` and `ignoreProps`), you can also specify the the following options that are specific to `elementOverrides`:
+
+- `allowElement` (default: `false`) - When `true` the rule will allow the specified element to have string literals as children, wrapped or unwrapped without warning.
+- `applyToNestedElements` (default: `true`) - When `false` the rule will not apply the current options set to nested elements. This is useful when you want to apply the rule to a specific element, but not to its children.
+
+**Note**: As this rule has no way of differentiating between different componets with the same name, it is recommended to use this option with specific components that are unique to your application.
+
+#### `elementOverrides` Examples
+
+The following are **correct** examples that demonstrate how to use the `elementOverrides` option:
+
+```js
+// "react/jsx-no-literals": [<enabled>, {"elementOverrides": { "Button": {"allowElement": true} }}]
+
+var Hello = <div>{'test'}</div>;
+var World = <Button>test</Button>;
+```
+
+```js
+// "react/jsx-no-literals": [<enabled>, {"elementOverrides": { "Text": {"allowElement": true} }}]
+
+var World = <Text>Hello <a href="a">world</a></Text>;
+```
+
+```js
+// "react/jsx-no-literals": [<enabled>, {"elementOverrides": { "Text": {"allowElement": true, "applyToNestedElements": false} }}]
+
+var linkText = 'world';
+var World = <Text>Hello <a href="a">{linkText}</a></Text>;
+```
+
+```js
+// "react/jsx-no-literals": [<enabled>, {"noStrings": true, "elementOverrides": { "Button": {"noStrings": false} }}]
+// OR
+// "react/jsx-no-literals": [<enabled>, {"noStrings": true, "elementOverrides": { "Button": {} }}]
+
+var test = 'test'
+var Hello = <div>{test}</div>;
+var World = <Button>{'test'}</Button>;
+```
+
+## Examples
 
 To use, you can specify as follows:
 

--- a/lib/rules/jsx-no-literals.js
+++ b/lib/rules/jsx-no-literals.js
@@ -8,6 +8,10 @@
 
 const iterFrom = require('es-iterator-helpers/Iterator.from');
 const map = require('es-iterator-helpers/Iterator.prototype.map');
+const some = require('es-iterator-helpers/Iterator.prototype.some');
+const flatMap = require('es-iterator-helpers/Iterator.prototype.flatMap');
+const fromEntries = require('object.fromentries');
+const entries = require('object.entries');
 
 const docsUrl = require('../util/docsUrl');
 const report = require('../util/report');
@@ -17,15 +21,165 @@ const getText = require('../util/eslint').getText;
 // Rule Definition
 // ------------------------------------------------------------------------------
 
-function trimIfString(val) {
-  return typeof val === 'string' ? val.trim() : val;
+/**
+ * @param {unknown} value
+ * @returns {string | unknown}
+ */
+function trimIfString(value) {
+  return typeof value === 'string' ? value.trim() : value;
 }
+
+const reOverridableElement = /^[A-Z][\w.]*$/;
+const reIsWhiteSpace = /^[\s]+$/;
+const jsxElementTypes = new Set(['JSXElement', 'JSXFragment']);
+const standardJSXNodeParentTypes = new Set(['JSXAttribute', 'JSXElement', 'JSXExpressionContainer', 'JSXFragment']);
 
 const messages = {
   invalidPropValue: 'Invalid prop value: "{{text}}"',
+  invalidPropValueInElement: 'Invalid prop value: "{{text}}" in {{element}}',
   noStringsInAttributes: 'Strings not allowed in attributes: "{{text}}"',
+  noStringsInAttributesInElement: 'Strings not allowed in attributes: "{{text}}" in {{element}}',
   noStringsInJSX: 'Strings not allowed in JSX files: "{{text}}"',
+  noStringsInJSXInElement: 'Strings not allowed in JSX files: "{{text}}" in {{element}}',
   literalNotInJSXExpression: 'Missing JSX expression container around literal string: "{{text}}"',
+  literalNotInJSXExpressionInElement: 'Missing JSX expression container around literal string: "{{text}}" in {{element}}',
+};
+
+/** @type {Exclude<import('eslint').Rule.RuleModule['meta']['schema'], unknown[]>['properties']} */
+const commonPropertiesSchema = {
+  noStrings: {
+    type: 'boolean',
+  },
+  allowedStrings: {
+    type: 'array',
+    uniqueItems: true,
+    items: {
+      type: 'string',
+    },
+  },
+  ignoreProps: {
+    type: 'boolean',
+  },
+  noAttributeStrings: {
+    type: 'boolean',
+  },
+};
+
+/**
+ * @typedef RawElementConfigProperties
+ * @property {boolean} [noStrings]
+ * @property {string[]} [allowedStrings]
+ * @property {boolean} [ignoreProps]
+ * @property {boolean} [noAttributeStrings]
+ *
+ * @typedef RawOverrideConfigProperties
+ * @property {boolean} [allowElement]
+ * @property {boolean} [applyToNestedElements=true]
+ *
+ * @typedef {RawElementConfigProperties} RawElementConfig
+ * @typedef {RawElementConfigProperties & RawElementConfigProperties} RawOverrideConfig
+ *
+ * @typedef RawElementOverrides
+ * @property {Record<string, RawOverrideConfig>} [elementOverrides]
+ *
+ * @typedef {RawElementConfig & RawElementOverrides} RawConfig
+ *
+ * ----------------------------------------------------------------------
+ *
+ * @typedef ElementConfigType
+ * @property {'element'} type
+ *
+ * @typedef ElementConfigProperties
+ * @property {boolean} noStrings
+ * @property {Set<string>} allowedStrings
+ * @property {boolean} ignoreProps
+ * @property {boolean} noAttributeStrings
+ *
+ * @typedef OverrideConfigProperties
+ * @property {'override'} type
+ * @property {string} name
+ * @property {boolean} allowElement
+ * @property {boolean} applyToNestedElements
+ *
+ * @typedef {ElementConfigType & ElementConfigProperties} ElementConfig
+ * @typedef {OverrideConfigProperties & ElementConfigProperties} OverrideConfig
+ *
+ * @typedef ElementOverrides
+ * @property {Record<string, OverrideConfig>} elementOverrides
+ *
+ * @typedef {ElementConfig & ElementOverrides} Config
+ * @typedef {Config | OverrideConfig} ResolvedConfig
+ */
+
+/**
+ * Normalizes the element portion of the config
+ * @param {RawConfig} config
+ * @returns {ElementConfig}
+ */
+function normalizeElementConfig(config) {
+  return {
+    type: 'element',
+    noStrings: !!config.noStrings,
+    allowedStrings: config.allowedStrings
+      ? new Set(map(iterFrom(config.allowedStrings), trimIfString))
+      : new Set(),
+    ignoreProps: !!config.ignoreProps,
+    noAttributeStrings: !!config.noAttributeStrings,
+  };
+}
+
+/**
+ * Normalizes the config and applies default values to all config options
+ * @param {RawConfig} config
+ * @returns {Config}
+ */
+function normalizeConfig(config) {
+  /** @type {Config} */
+  const normalizedConfig = Object.assign(normalizeElementConfig(config), {
+    elementOverrides: {},
+  });
+
+  if (config.elementOverrides) {
+    normalizedConfig.elementOverrides = fromEntries(
+      flatMap(
+        iterFrom(entries(config.elementOverrides)),
+        (entry) => {
+          const elementName = entry[0];
+          const rawElementConfig = entry[1];
+
+          if (!reOverridableElement.test(elementName)) {
+            return [];
+          }
+
+          return [[
+            elementName,
+            Object.assign(normalizeElementConfig(rawElementConfig), {
+              type: 'override',
+              name: elementName,
+              allowElement: !!rawElementConfig.allowElement,
+              applyToNestedElements: typeof rawElementConfig.applyToNestedElements === 'undefined' || !!rawElementConfig.applyToNestedElements,
+            }),
+          ]];
+        }
+      )
+    );
+  }
+
+  return normalizedConfig;
+}
+
+const elementOverrides = {
+  type: 'object',
+  patternProperties: {
+    [reOverridableElement.source]: {
+      type: 'object',
+      properties: Object.assign(
+        { applyToNestedElements: { type: 'boolean' } },
+        commonPropertiesSchema
+      ),
+
+    },
+  },
 };
 
 /** @type {import('eslint').Rule.RuleModule} */
@@ -42,48 +196,121 @@ module.exports = {
 
     schema: [{
       type: 'object',
-      properties: {
-        noStrings: {
-          type: 'boolean',
-        },
-        allowedStrings: {
-          type: 'array',
-          uniqueItems: true,
-          items: {
-            type: 'string',
-          },
-        },
-        ignoreProps: {
-          type: 'boolean',
-        },
-        noAttributeStrings: {
-          type: 'boolean',
-        },
-      },
+      properties: Object.assign(
+        { elementOverrides },
+        commonPropertiesSchema
+      ),
       additionalProperties: false,
     }],
   },
 
   create(context) {
-    const defaults = {
-      noStrings: false,
-      allowedStrings: [],
-      ignoreProps: false,
-      noAttributeStrings: false,
-    };
-    const config = Object.assign({}, defaults, context.options[0] || {});
-    config.allowedStrings = new Set(map(iterFrom(config.allowedStrings), trimIfString));
+    /** @type {RawConfig} */
+    const rawConfig = (context.options.length && context.options[0]) || {};
+    const config = normalizeConfig(rawConfig);
 
-    function defaultMessageId(ancestorIsJSXElement) {
-      if (config.noAttributeStrings && !ancestorIsJSXElement) {
-        return 'noStringsInAttributes';
+    const hasElementOverrides = Object.keys(config.elementOverrides).length > 0;
+
+    /** @type {Map<string, string>} */
+    const renamedImportMap = new Map();
+
+    /**
+     * Determines if the given expression is a require statement. Supports
+     * nested MemberExpresions. ie `require('foo').nested.property`
+     * @param {ASTNode} node
+     * @returns {boolean}
+     */
+    function isRequireStatement(node) {
+      if (node.type === 'CallExpression') {
+        if (node.callee.type === 'Identifier') {
+          return node.callee.name === 'require';
+        }
       }
-      if (config.noStrings) {
-        return 'noStringsInJSX';
+      if (node.type === 'MemberExpression') {
+        return isRequireStatement(node.object);
       }
-      return 'literalNotInJSXExpression';
+
+      return false;
     }
 
+    /** @typedef {{ name: string, compoundName?: string }} ElementNameFragment */
+
+    /**
+     * Gets the name of the given JSX element. Supports nested
+     * JSXMemeberExpressions. ie `<Namesapce.Component.SubComponent />`
+     * @param {ASTNode} node
+     * @returns {ElementNameFragment | undefined}
+     */
+    function getJSXElementName(node) {
+      if (node.openingElement.name.type === 'JSXIdentifier') {
+        const name = node.openingElement.name.name;
+        return {
+          name: renamedImportMap.get(name) || name,
+          compoundName: undefined,
+        };
+      }
+
+      /** @type {string[]} */
+      const nameFragments = [];
+
+      if (node.openingElement.name.type === 'JSXMemberExpression') {
+        /** @type {ASTNode} */
+        let current = node.openingElement.name;
+        while (current.type === 'JSXMemberExpression') {
+          if (current.property.type === 'JSXIdentifier') {
+            nameFragments.unshift(current.property.name);
+          }
+
+          current = current.object;
+        }
+
+        if (current.type === 'JSXIdentifier') {
+          nameFragments.unshift(current.name);
+
+          const rootFragment = nameFragments[0];
+          if (rootFragment) {
+            const rootFragmentRenamed = renamedImportMap.get(rootFragment);
+            if (rootFragmentRenamed) {
+              nameFragments[0] = rootFragmentRenamed;
+            }
+          }
+
+          const nameFragment = nameFragments[nameFragments.length - 1];
+          if (nameFragment) {
+            return {
+              name: nameFragment,
+              compoundName: nameFragments.join('.'),
+            };
+          }
+        }
+      }
+    }
+
+    /**
+     * Gets all JSXElement ancestor nodes for the given node
+     * @param {ASTNode} node
+     * @returns {ASTNode[]}
+     */
+    function getJSXElementAncestors(node) {
+      /** @type {ASTNode[]} */
+      const ancestors = [];
+
+      let current = node;
+      while (current) {
+        if (current.type === 'JSXElement') {
+          ancestors.push(current);
+        }
+
+        current = current.parent;
+      }
+
+      return ancestors;
+    }
+
+    /**
+     * @param {ASTNode} node
+     * @returns {ASTNode}
+     */
     function getParentIgnoringBinaryExpressions(node) {
       let current = node;
       while (current.parent.type === 'BinaryExpression') {
@@ -92,64 +319,132 @@ module.exports = {
       return current.parent;
     }
 
-    function getValidation(node) {
-      const values = [trimIfString(node.raw), trimIfString(node.value)];
-      if (values.some((value) => config.allowedStrings.has(value))) {
-        return false;
-      }
-
+    /**
+     * @param {ASTNode} node
+     * @returns {{ parent: ASTNode, grandParent: ASTNode }}
+     */
+    function getParentAndGrandParent(node) {
       const parent = getParentIgnoringBinaryExpressions(node);
-
-      function isParentNodeStandard() {
-        if (!/^[\s]+$/.test(node.value) && typeof node.value === 'string' && parent.type.includes('JSX')) {
-          if (config.noAttributeStrings) {
-            return parent.type === 'JSXAttribute' || parent.type === 'JSXElement';
-          }
-          if (!config.noAttributeStrings) {
-            return parent.type !== 'JSXAttribute';
-          }
-        }
-
-        return false;
-      }
-
-      const standard = isParentNodeStandard();
-
-      if (config.noStrings) {
-        return standard;
-      }
-      return standard && parent.type !== 'JSXExpressionContainer';
-    }
-
-    function getParentAndGrandParentType(node) {
-      const parent = getParentIgnoringBinaryExpressions(node);
-      const parentType = parent.type;
-      const grandParentType = parent.parent.type;
-
       return {
         parent,
-        parentType,
-        grandParentType,
         grandParent: parent.parent,
       };
     }
 
+    /**
+     * @param {ASTNode} node
+     * @returns {boolean}
+     */
     function hasJSXElementParentOrGrandParent(node) {
-      const parents = getParentAndGrandParentType(node);
-      const parentType = parents.parentType;
-      const grandParentType = parents.grandParentType;
-
-      return parentType === 'JSXFragment' || parentType === 'JSXElement' || grandParentType === 'JSXElement';
+      const ancestors = getParentAndGrandParent(node);
+      return some(iterFrom([ancestors.parent, ancestors.grandParent]), (parent) => jsxElementTypes.has(parent.type));
     }
 
-    function reportLiteralNode(node, messageId) {
-      const ancestorIsJSXElement = hasJSXElementParentOrGrandParent(node);
-      messageId = messageId || defaultMessageId(ancestorIsJSXElement);
+    /**
+     * Determines whether a given node's value and its immediate parent are
+     * viable text nodes that can/should be reported on
+     * @param {ASTNode} node
+     * @param {ResolvedConfig} resolvedConfig
+     * @returns {boolean}
+     */
+    function isViableTextNode(node, resolvedConfig) {
+      const textValues = iterFrom([trimIfString(node.raw), trimIfString(node.value)]);
+      if (some(textValues, (value) => resolvedConfig.allowedStrings.has(value))) {
+        return false;
+      }
 
+      const parent = getParentIgnoringBinaryExpressions(node);
+
+      let isStandardJSXNode = false;
+      if (typeof node.value === 'string' && !reIsWhiteSpace.test(node.value) && standardJSXNodeParentTypes.has(parent.type)) {
+        if (resolvedConfig.noAttributeStrings) {
+          isStandardJSXNode = parent.type === 'JSXAttribute' || parent.type === 'JSXElement';
+        } else {
+          isStandardJSXNode = parent.type !== 'JSXAttribute';
+        }
+      }
+
+      if (resolvedConfig.noStrings) {
+        return isStandardJSXNode;
+      }
+
+      return isStandardJSXNode && parent.type !== 'JSXExpressionContainer';
+    }
+
+    /**
+     * Gets an override config for a given node. For any given node, we also
+     * need to traverse the ancestor tree to determine if an ancestor's config
+     * will also apply to the current node.
+     * @param {ASTNode} node
+     * @returns {OverrideConfig | undefined}
+     */
+    function getOverrideConfig(node) {
+      if (!hasElementOverrides) {
+        return;
+      }
+
+      const allAncestorElements = getJSXElementAncestors(node);
+      if (!allAncestorElements.length) {
+        return;
+      }
+
+      for (const ancestorElement of allAncestorElements) {
+        const isClosestJSXAncestor = ancestorElement === allAncestorElements[0];
+
+        const ancestor = getJSXElementName(ancestorElement);
+        if (ancestor) {
+          if (ancestor.name) {
+            const ancestorElements = config.elementOverrides[ancestor.name];
+            const ancestorConfig = ancestor.compoundName
+              ? config.elementOverrides[ancestor.compoundName] || ancestorElements
+              : ancestorElements;
+
+            if (ancestorConfig) {
+              if (isClosestJSXAncestor || ancestorConfig.applyToNestedElements) {
+                return ancestorConfig;
+              }
+            }
+          }
+        }
+      }
+    }
+
+    /**
+     * @param {ResolvedConfig} resolvedConfig
+     * @returns {boolean}
+     */
+    function shouldAllowElement(resolvedConfig) {
+      return resolvedConfig.type === 'override' && 'allowElement' in resolvedConfig && !!resolvedConfig.allowElement;
+    }
+
+    /**
+     * @param {boolean} ancestorIsJSXElement
+     * @param {ResolvedConfig} resolvedConfig
+     * @returns {string}
+     */
+    function defaultMessageId(ancestorIsJSXElement, resolvedConfig) {
+      if (resolvedConfig.noAttributeStrings && !ancestorIsJSXElement) {
+        return resolvedConfig.type === 'override' ? 'noStringsInAttributesInElement' : 'noStringsInAttributes';
+      }
+
+      if (resolvedConfig.noStrings) {
+        return resolvedConfig.type === 'override' ? 'noStringsInJSXInElement' : 'noStringsInJSX';
+      }
+
+      return resolvedConfig.type === 'override' ? 'literalNotInJSXExpressionInElement' : 'literalNotInJSXExpression';
+    }
+
+    /**
+     * @param {ASTNode} node
+     * @param {string} messageId
+     * @param {ResolvedConfig} resolvedConfig
+     */
+    function reportLiteralNode(node, messageId, resolvedConfig) {
       report(context, messages[messageId], messageId, {
         node,
         data: {
           text: getText(context, node).trim(),
+          element: resolvedConfig.type === 'override' && 'name' in resolvedConfig ? resolvedConfig.name : undefined,
         },
       });
     }
@@ -158,39 +453,103 @@ module.exports = {
     // Public
     // --------------------------------------------------------------------------
 
-    return {
+    return Object.assign(hasElementOverrides ? {
+      // Get renamed import local names mapped to their imported name
+      ImportDeclaration(node) {
+        node.specifiers
+          .filter((s) => s.type === 'ImportSpecifier')
+          .forEach((specifier) => {
+            renamedImportMap.set(
+              (specifier.local || specifier.imported).name,
+              specifier.imported.name
+            );
+          });
+      },
+
+      // Get renamed destructured local names mapped to their imported name
+      VariableDeclaration(node) {
+        node.declarations
+          .filter((d) => (
+            d.type === 'VariableDeclarator'
+            && isRequireStatement(d.init)
+            && d.id.type === 'ObjectPattern'
+          ))
+          .forEach((declaration) => {
+            declaration.id.properties
+              .filter((property) => (
+                property.type === 'Property'
+                && property.key.type === 'Identifier'
+                && property.value.type === 'Identifier'
+              ))
+              .forEach((property) => {
+                renamedImportMap.set(property.value.name, property.key.name);
+              });
+          });
+      },
+    } : false, {
       Literal(node) {
-        if (getValidation(node) && (hasJSXElementParentOrGrandParent(node) || !config.ignoreProps)) {
-          reportLiteralNode(node);
+        const resolvedConfig = getOverrideConfig(node) || config;
+
+        const hasJSXParentOrGrandParent = hasJSXElementParentOrGrandParent(node);
+        if (hasJSXParentOrGrandParent && shouldAllowElement(resolvedConfig)) {
+          return;
+        }
+
+        if (isViableTextNode(node, resolvedConfig)) {
+          if (hasJSXParentOrGrandParent || !config.ignoreProps) {
+            reportLiteralNode(node, defaultMessageId(hasJSXParentOrGrandParent, resolvedConfig), resolvedConfig);
+          }
         }
       },
 
       JSXAttribute(node) {
-        const isNodeValueString = node && node.value && node.value.type === 'Literal' && typeof node.value.value === 'string' && !config.allowedStrings.has(node.value.value);
+        const isLiteralString = node.value.type === 'Literal'
+          && typeof node.value.value === 'string';
+        const isStringLiteral = node.value.type === 'StringLiteral';
 
-        if (config.noStrings && !config.ignoreProps && isNodeValueString) {
-          const messageId = 'invalidPropValue';
-          reportLiteralNode(node, messageId);
+        if (isLiteralString || isStringLiteral) {
+          const resolvedConfig = getOverrideConfig(node) || config;
+
+          if (
+            resolvedConfig.noStrings
+            && !resolvedConfig.ignoreProps
+            && !resolvedConfig.allowedStrings.has(node.value.value)
+          ) {
+            const messageId = resolvedConfig.type === 'override' ? 'invalidPropValueInElement' : 'invalidPropValue';
+            reportLiteralNode(node, messageId, resolvedConfig);
+          }
         }
       },
 
       JSXText(node) {
-        if (getValidation(node)) {
-          reportLiteralNode(node);
+        const resolvedConfig = getOverrideConfig(node) || config;
+
+        if (shouldAllowElement(resolvedConfig)) {
+          return;
+        }
+
+        if (isViableTextNode(node, resolvedConfig)) {
+          const hasJSXParendOrGrantParent = hasJSXElementParentOrGrandParent(node);
+          reportLiteralNode(node, defaultMessageId(hasJSXParendOrGrantParent, resolvedConfig), resolvedConfig);
         }
       },
 
       TemplateLiteral(node) {
-        const parents = getParentAndGrandParentType(node);
-        const parentType = parents.parentType;
-        const grandParentType = parents.grandParentType;
-        const isParentJSXExpressionCont = parentType === 'JSXExpressionContainer';
-        const isParentJSXElement = parentType === 'JSXElement' || grandParentType === 'JSXElement';
+        const ancestors = getParentAndGrandParent(node);
+        const isParentJSXExpressionCont = ancestors.parent.type === 'JSXExpressionContainer';
+        const isParentJSXElement = ancestors.grandParent.type === 'JSXElement';
 
-        if (isParentJSXExpressionCont && config.noStrings && (isParentJSXElement || !config.ignoreProps)) {
-          reportLiteralNode(node);
+        if (isParentJSXExpressionCont) {
+          const resolvedConfig = getOverrideConfig(node) || config;
+
+          if (
+            resolvedConfig.noStrings
+            && (isParentJSXElement || !resolvedConfig.ignoreProps)
+          ) {
+            reportLiteralNode(node, defaultMessageId(isParentJSXElement, resolvedConfig), resolvedConfig);
+          }
         }
       },
-    };
+    });
   },
 };

--- a/tests/lib/rules/jsx-no-literals.js
+++ b/tests/lib/rules/jsx-no-literals.js
@@ -296,6 +296,186 @@ ruleTester.run('jsx-no-literals', rule, {
       `,
       options: [{ noStrings: true, allowedStrings: ['&mdash;', '—'] }],
     },
+    {
+      code: `
+        <T>foo</T>
+      `,
+      options: [{ elementOverrides: { T: { allowElement: true } } }],
+    },
+    {
+      code: `
+        <T>foo <div>bar</div></T>
+      `,
+      options: [{ elementOverrides: { T: { allowElement: true } } }],
+    },
+    {
+      code: `
+        <T>foo <div>{'bar'}</div></T>
+      `,
+      options: [{ elementOverrides: { T: { allowElement: true, applyToNestedElements: false } } }],
+    },
+    {
+      code: `
+        <div>
+          <div>{'foo'}</div>
+          <T>{2}</T>
+        </div>
+      `,
+      options: [{ elementOverrides: { T: { noStrings: true } } }],
+    },
+    {
+      code: `
+        <T>{2}<div>{2}</div></T>
+      `,
+      options: [{ elementOverrides: { T: { noStrings: true } } }],
+    },
+    {
+      code: `
+        <T>{2}<div>{'foo'}</div></T>
+      `,
+      options: [{ elementOverrides: { T: { noStrings: true, applyToNestedElements: false } } }],
+    },
+    {
+      code: `
+        <div>
+          <div>{'foo'}</div>
+          <T>foo</T>
+        </div>
+      `,
+      options: [{ elementOverrides: { T: { allowedStrings: ['foo'] } } }],
+    },
+    {
+      code: `
+        <T>foo<div>foo</div></T>
+      `,
+      options: [{ elementOverrides: { T: { allowedStrings: ['foo'] } } }],
+    },
+    {
+      code: `
+        <T>foo<div>{'foo'}</div></T>
+      `,
+      options: [{ elementOverrides: { T: { allowedStrings: ['foo'], applyToNestedElements: false } } }],
+    },
+    {
+      code: `
+        <div>
+          <div foo={2} />
+          <T foo="bar" />
+        </div>
+      `,
+      options: [{ noStrings: true, elementOverrides: { T: { noStrings: true, ignoreProps: true } } }],
+    },
+    {
+      code: `
+        <T foo="bar"><div foo="bar" /></T>
+      `,
+      options: [{ noStrings: true, elementOverrides: { T: { noStrings: true, ignoreProps: true } } }],
+    },
+    {
+      code: `
+        <T foo="bar"><div foo={2} /></T>
+      `,
+      options: [{ noStrings: true, elementOverrides: { T: { noStrings: true, ignoreProps: true, applyToNestedElements: false } } }],
+    },
+    {
+      code: `
+        <div>
+          <div foo="foo" />
+          <T foo={2} />
+        </div>
+      `,
+      options: [{ elementOverrides: { T: { noAttributeStrings: true } } }],
+    },
+    {
+      code: `
+        <T foo={2}><div foo={2} /></T>
+      `,
+      options: [{ elementOverrides: { T: { noAttributeStrings: true } } }],
+    },
+    {
+      code: `
+        <T foo={2}><div foo="foo" /></T>
+      `,
+      options: [{ elementOverrides: { T: { noAttributeStrings: true, applyToNestedElements: false } } }],
+    },
+    {
+      code: `
+        <T>foo<U>foo</U></T>
+      `,
+      options: [{ elementOverrides: { T: { allowedStrings: ['foo'] }, U: { allowedStrings: ['foo'] } } }],
+    },
+    {
+      code: `
+        import { T } from 'foo';
+        <T>{'foo'}</T>
+      `,
+    },
+    {
+      code: `
+        import { T as U } from 'foo';
+        <U>foo</U>
+      `,
+      options: [{ elementOverrides: { T: { allowElement: true } } }],
+    },
+    {
+      code: `
+        const { T: U } = require('foo');
+        <U>foo</U>
+      `,
+      options: [{ elementOverrides: { T: { allowElement: true } } }],
+    },
+    {
+      code: `
+        const { T: U } = require('foo').Foo;
+        <U>foo</U>
+      `,
+      options: [{ elementOverrides: { T: { allowElement: true } } }],
+    },
+    {
+      code: `
+        const { T: U } = require('foo').Foo.Foo;
+        <U>foo</U>
+      `,
+      options: [{ elementOverrides: { T: { allowElement: true } } }],
+    },
+    {
+      code: `
+        const foo = 2;
+        <T>foo</T>
+      `,
+      options: [{ elementOverrides: { T: { allowElement: true } } }],
+    },
+    {
+      code: `
+        <T.U>foo</T.U>
+      `,
+      options: [{ elementOverrides: { 'T.U': { allowElement: true } } }],
+    },
+    {
+      code: `
+        import { T as U } from 'foo';
+        <U.U>foo</U.U>
+      `,
+      options: [{ elementOverrides: { 'T.U': { allowElement: true } } }],
+    },
+    {
+      code: `
+        <React.Fragment>foo</React.Fragment>
+      `,
+      options: [{ elementOverrides: { Fragment: { allowElement: true } } }],
+    },
+    {
+      code: `
+        <React.Fragment>foo</React.Fragment>
+      `,
+      options: [{ elementOverrides: { 'React.Fragment': { allowElement: true } } }],
+    },
+    {
+      code: `
+        <div>{'foo'}</div>
+      `,
+      options: [{ elementOverrides: { div: { allowElement: true } } }],
+    },
   ]),
 
   invalid: parsers.all([
@@ -521,6 +701,7 @@ ruleTester.run('jsx-no-literals', rule, {
         },
       ],
     },
+    /* eslint-disable no-template-curly-in-string */
     {
       code: '<Foo bar={`${baz}`} />',
       options: [{ noStrings: true, ignoreProps: false }],
@@ -541,6 +722,7 @@ ruleTester.run('jsx-no-literals', rule, {
         },
       ],
     },
+    /* eslint-enable no-template-curly-in-string */
     {
       code: '<Foo bar={`foo` + \'bar\'} />',
       options: [{ noStrings: true, ignoreProps: false }],
@@ -662,6 +844,330 @@ ruleTester.run('jsx-no-literals', rule, {
           data: { text: 'baz bob' },
         },
       ],
+    },
+    {
+      code: `
+        <div>
+          <div>foo</div>
+          <T>bar</T>
+        </div>
+      `,
+      options: [{ elementOverrides: { T: {} } }],
+      errors: [
+        { messageId: 'literalNotInJSXExpression', data: { text: 'foo' } },
+        { messageId: 'literalNotInJSXExpressionInElement', data: { text: 'bar', element: 'T' } },
+      ],
+    },
+    {
+      code: `
+        <div>
+          <div>foo</div>
+          <T>bar</T>
+        </div>
+      `,
+      options: [{ elementOverrides: { T: { allowElement: true } } }],
+      errors: [
+        { messageId: 'literalNotInJSXExpression', data: { text: 'foo' } },
+      ],
+    },
+    {
+      code: `
+        <T>foo <div>bar</div></T>
+      `,
+      options: [{ elementOverrides: { T: { allowElement: true, applyToNestedElements: false } } }],
+      errors: [{ messageId: 'literalNotInJSXExpression', data: { text: 'bar' } }],
+    },
+    {
+      code: `
+        <div>
+          <div>foo</div>
+          <T>{'bar'}</T>
+        </div>
+      `,
+      options: [{ elementOverrides: { T: { noStrings: true } } }],
+      errors: [
+        { messageId: 'literalNotInJSXExpression', data: { text: 'foo' } },
+        { messageId: 'noStringsInJSXInElement', data: { text: '\'bar\'', element: 'T' } },
+      ],
+    },
+    {
+      code: `
+        <div>
+          <div>foo</div>
+          <T>{'bar'}<div>{'baz'}</div></T>
+        </div>
+      `,
+      options: [{ elementOverrides: { T: { noStrings: true } } }],
+      errors: [
+        { messageId: 'literalNotInJSXExpression', data: { text: 'foo' } },
+        { messageId: 'noStringsInJSXInElement', data: { text: '\'bar\'', element: 'T' } },
+        { messageId: 'noStringsInJSXInElement', data: { text: '\'baz\'', element: 'T' } },
+      ],
+    },
+    {
+      code: `
+        <div>
+          <div>foo</div>
+          <T>{'bar'}<div>{'baz'}</div></T>
+        </div>
+      `,
+      options: [{ elementOverrides: { T: { noStrings: true, applyToNestedElements: false } } }],
+      errors: [
+        { messageId: 'literalNotInJSXExpression', data: { text: 'foo' } },
+        { messageId: 'noStringsInJSXInElement', data: { text: '\'bar\'', element: 'T' } },
+      ],
+    },
+    {
+      code: `
+        <div>
+          <div>{'foo'}</div>
+          <T>{'foo'}</T>
+        </div>
+      `,
+      options: [{ noStrings: true, elementOverrides: { T: { noStrings: true, allowedStrings: ['foo'] } } }],
+      errors: [
+        { messageId: 'noStringsInJSX', data: { text: '\'foo\'' } },
+      ],
+    },
+    {
+      code: `
+        <div>
+          <div>{'foo'}</div>
+          <T>{'foo'}<div>{'foo'}</div></T>
+        </div>
+      `,
+      options: [{ noStrings: true, elementOverrides: { T: { noStrings: true, allowedStrings: ['foo'] } } }],
+      errors: [
+        { messageId: 'noStringsInJSX', data: { text: '\'foo\'' } },
+      ],
+    },
+    {
+      code: `
+        <div>
+          <div>{'foo'}</div>
+          <T>{'foo'}<div>{'foo'}</div></T>
+        </div>
+      `,
+      options: [{ noStrings: true, elementOverrides: { T: { noStrings: true, allowedStrings: ['foo'], applyToNestedElements: false } } }],
+      errors: [
+        { messageId: 'noStringsInJSX', data: { text: '\'foo\'' } },
+        { messageId: 'noStringsInJSX', data: { text: '\'foo\'' } },
+      ],
+    },
+    {
+      code: `
+        <div>
+          <div foo1="bar" />
+          <T foo2="bar" />
+        </div>
+      `,
+      options: [{ noStrings: true, elementOverrides: { T: { noStrings: true, ignoreProps: true } } }],
+      errors: [
+        { messageId: 'invalidPropValue', data: { text: 'foo1="bar"' } },
+      ],
+    },
+    {
+      code: `
+        <div>
+          <div foo1="bar" />
+          <T foo2="bar"><div foo3="bar" /></T>
+        </div>
+      `,
+      options: [{ noStrings: true, elementOverrides: { T: { noStrings: true, ignoreProps: true } } }],
+      errors: [
+        { messageId: 'invalidPropValue', data: { text: 'foo1="bar"' } },
+      ],
+    },
+    {
+      code: `
+        <div>
+          <div foo1="bar" />
+          <T foo2="bar"><div foo3="bar" /></T>
+        </div>
+      `,
+      options: [{ noStrings: true, elementOverrides: { T: { noStrings: true, ignoreProps: true, applyToNestedElements: false } } }],
+      errors: [
+        { messageId: 'invalidPropValue', data: { text: 'foo1="bar"' } },
+        { messageId: 'invalidPropValue', data: { text: 'foo3="bar"' } },
+      ],
+    },
+    {
+      code: `
+        <div>
+          <div foo1="bar1" />
+          <T foo2="bar2" />
+        </div>
+      `,
+      options: [{ elementOverrides: { T: { noAttributeStrings: true } } }],
+      errors: [
+        { messageId: 'noStringsInAttributesInElement', data: { text: '"bar2"', element: 'T' } },
+      ],
+    },
+    {
+      code: `
+        <div>
+          <div foo1="bar1" />
+          <T foo2="bar2"><div foo3="bar3" /></T>
+        </div>
+      `,
+      options: [{ elementOverrides: { T: { noAttributeStrings: true } } }],
+      errors: [
+        { messageId: 'noStringsInAttributesInElement', data: { text: '"bar2"', element: 'T' } },
+        { messageId: 'noStringsInAttributesInElement', data: { text: '"bar3"', element: 'T' } },
+      ],
+    },
+    {
+      code: `
+        <div>
+          <div foo1="bar1" />
+          <T foo2="bar2"><div foo3="bar3" /></T>
+        </div>
+      `,
+      options: [{ elementOverrides: { T: { noAttributeStrings: true, applyToNestedElements: false } } }],
+      errors: [
+        { messageId: 'noStringsInAttributesInElement', data: { text: '"bar2"', element: 'T' } },
+      ],
+    },
+    {
+      code: `
+        <div>
+          <div>{'foo'}</div>
+          <T>{'bar'}</T>
+        </div>
+      `,
+      options: [{ noStrings: true, elementOverrides: { T: {} } }],
+      errors: [
+        { messageId: 'noStringsInJSX', data: { text: '\'foo\'' } },
+      ],
+    },
+    {
+      code: `
+        <div>
+          <div>foo</div>
+          <T>foo</T>
+        </div>
+      `,
+      options: [{ allowedStrings: ['foo'], elementOverrides: { T: {} } }],
+      errors: [
+        { messageId: 'literalNotInJSXExpressionInElement', data: { text: 'foo', element: 'T' } },
+      ],
+    },
+    {
+      code: `
+        <div>
+          <div>foo</div>
+          <T>foo</T>
+          <T>bar</T>
+          <T>baz</T>
+        </div>
+      `,
+      options: [{ allowedStrings: ['foo'], elementOverrides: { T: { allowedStrings: ['bar'] } } }],
+      errors: [
+        { messageId: 'literalNotInJSXExpressionInElement', data: { text: 'foo', element: 'T' } },
+        { messageId: 'literalNotInJSXExpressionInElement', data: { text: 'baz', element: 'T' } },
+      ],
+    },
+    {
+      code: `
+        <div>
+          <div foo1="bar1" />
+          <T foo2="bar2" />
+        </div>
+      `,
+      options: [{ noStrings: true, ignoreProps: true, elementOverrides: { T: { noStrings: true } } }],
+      errors: [
+        { messageId: 'invalidPropValueInElement', data: { text: 'foo2="bar2"', element: 'T' } },
+      ],
+    },
+    {
+      code: `
+        <div>
+          <div foo1="bar1" />
+          <T foo2="bar2" />
+        </div>
+      `,
+      options: [{ noAttributeStrings: true, elementOverrides: { T: {} } }],
+      errors: [
+        { messageId: 'noStringsInAttributes', data: { text: '"bar1"' } },
+      ],
+    },
+    {
+      code: `
+        <div>
+          <T>foo</T>
+          <U>bar</U>
+        </div>
+      `,
+      options: [{ elementOverrides: { T: {}, U: {} } }],
+      errors: [
+        { messageId: 'literalNotInJSXExpressionInElement', data: { text: 'foo', element: 'T' } },
+        { messageId: 'literalNotInJSXExpressionInElement', data: { text: 'bar', element: 'U' } },
+      ],
+    },
+    {
+      code: `
+        <div>
+          <T>foo</T>
+          <U>bar</U>
+        </div>
+      `,
+      options: [{ elementOverrides: { T: {}, U: { allowElement: true } } }],
+      errors: [
+        { messageId: 'literalNotInJSXExpressionInElement', data: { text: 'foo', element: 'T' } },
+      ],
+    },
+    {
+      code: `
+        <T>foo <U>bar</U></T>
+      `,
+      options: [{ elementOverrides: { T: {}, U: { allowElement: true } } }],
+      errors: [
+        { messageId: 'literalNotInJSXExpressionInElement', data: { text: 'foo', element: 'T' } },
+      ],
+    },
+    {
+      code: `
+        <T>{'foo'}<U>{'bar'}</U></T>
+      `,
+      options: [{ elementOverrides: { T: { noStrings: true }, U: {} } }],
+      errors: [
+        { messageId: 'noStringsInJSXInElement', data: { text: '\'foo\'', element: 'T' } },
+      ],
+    },
+    {
+      code: `
+        <T>foo<U>foo</U></T>
+      `,
+      options: [{ elementOverrides: { T: { allowedStrings: ['foo'] }, U: {} } }],
+      errors: [
+        { messageId: 'literalNotInJSXExpressionInElement', data: { text: 'foo', element: 'U' } },
+      ],
+    },
+    {
+      code: `
+        <T>foo<U>foo</U></T>
+      `,
+      options: [{ elementOverrides: { T: {}, U: { allowedStrings: ['foo'] } } }],
+      errors: [
+        { messageId: 'literalNotInJSXExpressionInElement', data: { text: 'foo', element: 'T' } },
+      ],
+    },
+    {
+      code: `
+        <div>
+          <Fragment>foo</Fragment>
+          <React.Fragment>foo</React.Fragment>
+        </div>
+      `,
+      options: [{ elementOverrides: { 'React.Fragment': { allowElement: true } } }],
+      errors: [{ messageId: 'literalNotInJSXExpression', data: { text: 'foo' } }],
+    },
+    {
+      code: `
+        <div>foo</div>
+      `,
+      options: [{ elementOverrides: { div: { allowElement: true } } }],
+      errors: [{ messageId: 'literalNotInJSXExpression', data: { text: 'foo' } }],
     },
   ]),
 });


### PR DESCRIPTION
Resolves #3808

Preface - I didn't intend to rewrite the whole rule, but I ended up needing to re-write the way the rule fetches and applies the config which resulted in the majority of the rule being reworked. 

### What is the purpose of this PR?

Adds a new option, `elementOverrides` which adds the ability to override the rule options for any named component. Specifying options within `elementOverrides` creates a new context for the rule, so the rule will only apply the new options to the specified element and its children (if
`applyToNestedElements` is `true` - see below). This means that the root rule options will not apply to the specified element.

`elementOverrides` is an object where the keys are the element names and the values are objects with the same options that this rule previously supported (`noStrings`, `allowedStrings`, `noAttributeStrings` and `ignoreProps`). `elementOverrides` also supports 2 new options: `allowElement` and `applyToNestedElements`.

- `allowElement` (default: `false`) - When `true` the rule will allow the specified element to have string literals as children, wrapped or unwrapped without warning. If the `noStrings` option is also specified, then only unwrapped literals will be allowed through. This option satisfies #3808.
- `applyToNestedElements` (default: `true`) - When `false` the rule will not apply the current options set to nested elements. This is useful when you want to apply the rule to a specific element, but not to its children.

The element name must match the following [regular expression](https://regex101.com/r/mX5rZV/1). It does not support intrinsic JSX elements (ie. `div` or `span`) and all elements that do not match the pattern will be filtered out when the config is normalized. The element name can also be a compound/namespaced/sub component (`JSXMemberExpression`) like `Modal.Button` or `React.Fragment`. If an element name like `Fragment` is specified, the override config will match on either of the following components:
```
<Fragment>text</Fragment>
<React.Fragment>text</React.Fragment>
```

The rule will also construct a simple import (or require) map specifically for renamed imports (ie `import { A as B } from 'c';`. The rule will match on the original (`imported`) specifier instead of the renamed (`local`) specifier. 

### What should reviewers focus on?

Most of the actual rule/option logic has remained unchanged. However, I re-ordered some of the node visitors for performance with regards to when `getOverrideConfig` is called since it is a relatively expensive function. Also, a lot of the visitor functions needed the current config passed in which required some changes within those too.

### How is this PR tested?

This PR adds roughly 50 tests. Each option (new and old) is individually tested for both valid and invalid cases. For each option, there are roughly 3 states that are tested:
1. Just an override
2. An override with nested elements
3. A root config and an override

All extraneous features are also tested such as imports/requires renames, the element name pattern and compound components

Based on a manual scan of the coverage report, I think all branches that need to be covered have been covered by tests. There are a few extra that exist to validate type check.