### PR TITLE
[Docs] `no-danger`: update broken link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,10 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 ### Changed
 * [Tests] add @typescript-eslint/parser v6 ([#3629][] @HenryBrown0)
 * [Tests] add @typescript-eslint/parser v7 and v8 ([#3629][] @hampustagerud)
+* [Docs] [`no-danger`]: update broken link ([#3817][] @lucasrmendonca)
 
 [#3629]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3629
+[#3817]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3817
 [#3807]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3807
 
 ## [7.35.2] - 2024.09.03

--- a/docs/rules/no-danger.md
+++ b/docs/rules/no-danger.md
@@ -2,9 +2,9 @@
 
 <!-- end auto-generated rule header -->
 
-Dangerous properties in React are those whose behavior is known to be a common source of application vulnerabilities. The properties names clearly indicate they are dangerous and should be avoided unless great care is taken.
+Dangerous properties in React are those whose behavior is known to be a common source of application vulnerabilities. The properties' names clearly indicate they are dangerous and should be avoided unless great care is taken.
 
-See <https://facebook.github.io/react/tips/dangerously-set-inner-html.html>
+See <https://react.dev/reference/react-dom/components/common#dangerously-setting-the-inner-html>
 
 ## Rule Details
 


### PR DESCRIPTION
Before, the URL was broken and pointed to a 404 Not Found page.
Now, the URL has been corrected