### PR TITLE
[Fix] `no-is-mounted`: fix logic in method name check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 
 ## Unreleased
 
+### Fixed
+* [`no-is-mounted`]: fix logic in method name check ([#3821][] @Mathias-S)
+
+[#3821]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3821
+
 ## [7.36.0] - 2024.09.12
 
 ### Added

--- a/lib/rules/no-is-mounted.js
+++ b/lib/rules/no-is-mounted.js
@@ -41,7 +41,8 @@ module.exports = {
         }
         if (
           callee.object.type !== 'ThisExpression'
-          && (!('name' in callee.property) || callee.property.name !== 'isMounted')
+          || !('name' in callee.property)
+          || callee.property.name !== 'isMounted'
         ) {
           return;
         }

--- a/tests/lib/rules/no-is-mounted.js
+++ b/tests/lib/rules/no-is-mounted.js
@@ -57,6 +57,17 @@ ruleTester.run('no-is-mounted', rule, {
         });
       `,
     },
+    {
+      code: `
+        class Hello extends React.Component {
+          notIsMounted() {}
+          render() {
+            this.notIsMounted();
+            return <div>Hello</div>;
+          }
+        };
+      `,
+    },
   ]),
 
   invalid: parsers.all([


### PR DESCRIPTION
The last change to `no-is-mounted` caused the rule to error with any method name, not just with "isMounted".

Fixes #3819