### PR TITLE
[Fix] `jsx-no-literals`: Avoid crashing on valueless boolean props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 
 ### Fixed
 * [`no-is-mounted`]: fix logic in method name check ([#3821][] @Mathias-S)
+* [`jsx-no-literals`]: Avoid crashing on valueless boolean props ([#3823][] @reosarevok)
 
+[#3823]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3823
 [#3821]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3821
 
 ## [7.36.0] - 2024.09.12

--- a/lib/rules/jsx-no-literals.js
+++ b/lib/rules/jsx-no-literals.js
@@ -503,9 +503,9 @@ module.exports = {
       },
 
       JSXAttribute(node) {
-        const isLiteralString = node.value.type === 'Literal'
+        const isLiteralString = node.value && node.value.type === 'Literal'
           && typeof node.value.value === 'string';
-        const isStringLiteral = node.value.type === 'StringLiteral';
+        const isStringLiteral = node.value && node.value.type === 'StringLiteral';
 
         if (isLiteralString || isStringLiteral) {
           const resolvedConfig = getOverrideConfig(node) || config;


### PR DESCRIPTION
b8217ed5f4104bd18b54f77ea108ec081ebbbd49 removed the `node.value` check leading to this crashing on any valueless boolean prop such as `<Component isWhatever />`

This just readds the check.

Fixes https://github.com/jsx-eslint/eslint-plugin-react/issues/3820