### PR TITLE
[readme] flat config example for react 17+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,13 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 * [`forbid-component-props`]: add `allowedForPatterns`/`disallowedForPatterns` options ([#3805][] @Efimenko)
 * [`no-unstable-nested-components`]: add `propNamePattern` to support custom render prop naming conventions ([#3826][] @danreeves)
 
+### Changed
+* [readme] flat config example for react 17+ ([#3824][] @GabenGar)
+
 [#3831]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3831
 [#3830]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3830
 [#3826]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3826
+[#3824]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3824
 [#3805]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3805
 
 ## [7.36.1] - 2024.09.12

--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ const reactPlugin = require('eslint-plugin-react');
 module.exports = [
   …
   reactPlugin.configs.flat.recommended, // This is not a plugin object, but a shareable config object
+  reactPlugin.configs.flat['jsx-runtime'], // Add this if you are using React 17+
   …
 ];
 ```


### PR DESCRIPTION
Contrary to what [the comment](https://github.com/jsx-eslint/eslint-plugin-react/issues/3770#issuecomment-2179919625) says, a link to [this snippet](https://github.com/jsx-eslint/eslint-plugin-react/blob/c8917b0885094b5e4cc2a6f613f7fb6f16fe932e/index.js#L163-L176) is a red herring and adding `jsx-runtime` config to array is enough for error to go way.