### PR TITLE
Add JSDoc type annotations and Update @types/eslint Version

### DIFF
--- a/lib/rules/forward-ref-uses-ref.js
+++ b/lib/rules/forward-ref-uses-ref.js
@@ -41,6 +41,7 @@ const messages = {
   removeForwardRef: 'Remove forwardRef wrapper',
 };
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {

--- a/lib/rules/jsx-props-no-spread-multi.js
+++ b/lib/rules/jsx-props-no-spread-multi.js
@@ -16,6 +16,7 @@ const messages = {
   noMultiSpreading: 'Spreading the same expression multiple times is forbidden',
 };
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     docs: {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@babel/plugin-syntax-do-expressions": "^7.24.7",
     "@babel/plugin-syntax-function-bind": "^7.24.7",
     "@babel/preset-react": "^7.24.7",
-    "@types/eslint": "=7.2.10",
+    "@types/eslint": "=8.56.10",
     "@types/estree": "0.0.52",
     "@types/node": "^4.9.5",
     "@typescript-eslint/parser": "^2.34.0 || ^3.10.1 || ^4 || ^5 || ^6.20 || ^7.14.1 || ^8.4",


### PR DESCRIPTION
Addressed the following:
- Added JSDoc annotations to rules.
- Updated `@types/eslint`version
  Note: Updated because the current version does not define the type for `RuleMetaData.hasSuggestions`.
  
 Related Issue: #3728