### PR TITLE
[readme] Fix shared settings link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 
 ## Unreleased
 
+### Changed
+* [readme] Fix shared settings link ([#3834][] @MgenGlder)
+
+[#3834]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3834
+
 ## [7.37.0] - 2024.09.26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Use [our preset](#recommended) to get reasonable defaults:
 
 If you are using the [new JSX transform from React 17](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#removing-unused-react-imports), extend [`react/jsx-runtime`](https://github.com/jsx-eslint/eslint-plugin-react/blob/c8917b0885094b5e4cc2a6f613f7fb6f16fe932e/index.js#L163-L176) in your eslint config (add `"plugin:react/jsx-runtime"` to `"extends"`) to disable the relevant rules.
 
-You should also specify settings that will be shared across all the plugin rules. ([More about eslint shared settings](https://eslint.org/docs/user-guide/configuring/configuration-files#adding-shared-settings))
+You should also specify settings that will be shared across all the plugin rules. ([More about eslint shared settings](https://eslint.org/docs/latest/use/configure/configuration-files#configuring-shared-settings))
 
 ```json5
 {


### PR DESCRIPTION
## Summary
- Updates the link to the eslint shared settings page in the `README.md` file.

As I was upgrading my eslint configuration for a personal project, I found that I needed to use the shared settings feature to configure my React version. The link in the docs section navigates to the main page but doesn't anchor you to the section that discusses the shared settings. I think the original link broke at some point. This PR fixes it.

