### PR TITLE
[Tests] `jsx-no-script-url`: Improve tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 ### Fixed
 * [`no-danger`]: avoid a crash on a nested component name ([#3833][] @ljharb)
 
+### Changed
+* [Tests] [`jsx-no-script-url`]: Improve tests ([#3849][] @radu2147)
+
+[#3849]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3849
 [#3833]: https://github.com/jsx-eslint/eslint-plugin-react/issues/3833
 
 ## [7.37.2] - 2024.10.22

--- a/tests/lib/rules/jsx-no-script-url.js
+++ b/tests/lib/rules/jsx-no-script-url.js
@@ -39,6 +39,10 @@ ruleTester.run('jsx-no-script-url', rule, {
     { code: '<Foo href="javascript:"></Foo>' },
     { code: '<a href />' },
     {
+      code: '<Foo other="javascript:"></Foo>',
+      options: [[{ name: 'Foo', props: ['to', 'href'] }]],
+    },
+    {
       code: '<Foo href="javascript:"></Foo>',
       settings: {
         linkComponents: [{ name: 'Foo', linkAttribute: ['to', 'href'] }],
@@ -47,6 +51,13 @@ ruleTester.run('jsx-no-script-url', rule, {
     {
       code: '<Foo href="javascript:"></Foo>',
       options: [[], { includeFromSettings: false }],
+      settings: {
+        linkComponents: [{ name: 'Foo', linkAttribute: ['to', 'href'] }],
+      },
+    },
+    {
+      code: '<Foo other="javascript:"></Foo>',
+      options: [[], { includeFromSettings: true }],
       settings: {
         linkComponents: [{ name: 'Foo', linkAttribute: ['to', 'href'] }],
       },


### PR DESCRIPTION
While developing [this](https://github.com/oxc-project/oxc/pull/6995), I noticed that test files for this rule don't explicitly cover the case when a non `linkAttribute`/`props` from a link component has the `"javascript:"` value. The rule seems to behave correctly for that case, so what I did in this PR is just to add a few tests for that.