### PR TITLE
[New] `jsx-sort-props`: add `className` to `RESERVED_PROPS_LIST`

### DIFF
--- a/docs/rules/jsx-sort-props.md
+++ b/docs/rules/jsx-sort-props.md
@@ -122,7 +122,7 @@ When `true`, alphabetical order is **not** enforced:
 
 This can be a boolean or an array option.
 
-When `reservedFirst` is defined, React reserved props (`children`, `dangerouslySetInnerHTML` - **only for DOM components**, `key`, and `ref`) must be listed before all other props, but still respecting the alphabetical order:
+When `reservedFirst` is defined, React reserved props (`children`, `dangerouslySetInnerHTML` - **only for DOM components**, `key`, and `ref`) or `className` must be listed before all other props, but still respecting the alphabetical order:
 
 ```jsx
 <Hello key={0} ref={johnRef} name="John">
@@ -130,7 +130,7 @@ When `reservedFirst` is defined, React reserved props (`children`, `dangerouslyS
 </Hello>
 ```
 
-If given as an array, the array's values will override the default list of reserved props. **Note**: the values in the array may only be a **subset** of React reserved props.
+If given as an array, the array's values will override the default list of reserved props. **Note**: the values in the array may only be a **subset** of React reserved props or `className`.
 
 With `reservedFirst: ["key"]`, the following will **not** warn:
 

--- a/lib/rules/jsx-sort-props.js
+++ b/lib/rules/jsx-sort-props.js
@@ -43,6 +43,7 @@ const RESERVED_PROPS_LIST = [
   'dangerouslySetInnerHTML',
   'key',
   'ref',
+  'className',
 ];
 
 function isReservedPropName(name, list) {


### PR DESCRIPTION
This PR brings a new `className` prop to `RESERVED_PROPS_LIST` at `jsx-sort-props` rule. Related to this issue: https://github.com/jsx-eslint/eslint-plugin-react/issues/3175

**Context**
In many organizations, including ours, there is a coding standard that requires the `className` prop to be listed before all other props. This practice enhances code readability and consistency, making it easier for developers to quickly identify the styling-related aspects of a component.

**Justification**
While the current `RESERVED_PROPS_LIST` is designed to include only React's reserved props (children, dangerouslySetInnerHTML, key, ref), the addition of `className` aligns with a common industry practice that prioritizes styling props for better visibility. This change would provide flexibility for teams that adhere to this convention without impacting those who do not.

@ljharb, I completely understand the importance of maintaining the integrity of the reserved props list. However, given the widespread adoption of this convention, I believe that including `className` could benefit many teams. I hope you will consider this addition to support a broader range of coding standards.

Thank you for considering this request. 🙏