### PR TITLE
[New] `jsx-props-no-multi-spaces`: Add automatic fix for no line gap between props

### DIFF
--- a/lib/rules/jsx-props-no-multi-spaces.js
+++ b/lib/rules/jsx-props-no-multi-spaces.js
@@ -80,6 +80,22 @@ module.exports = {
             prop1: getPropName(prev),
             prop2: getPropName(node),
           },
+          fix(fixer) {
+            const comments = sourceCode.getCommentsBefore ? sourceCode.getCommentsBefore(node) : [];
+            const nodes = [].concat(prev, comments, node);
+            const fixes = [];
+
+            for (let i = 1; i < nodes.length; i += 1) {
+              const prevNode = nodes[i - 1];
+              const currNode = nodes[i];
+              if (currNode.loc.start.line - prevNode.loc.end.line >= 2) {
+                const indent = ' '.repeat(currNode.loc.start.column);
+                fixes.push(fixer.replaceTextRange([prevNode.range[1], currNode.range[0]], `\n${indent}`));
+              }
+            }
+
+            return fixes;
+          },
         });
       }
 

--- a/tests/lib/rules/jsx-props-no-multi-spaces.js
+++ b/tests/lib/rules/jsx-props-no-multi-spaces.js
@@ -263,6 +263,12 @@ ruleTester.run('jsx-props-no-multi-spaces', rule, {
           type="button"
         />
       `,
+      output: `
+        <button
+          title='Some button'
+          type="button"
+        />
+      `,
       errors: [
         {
           messageId: 'noLineGap',
@@ -279,6 +285,15 @@ ruleTester.run('jsx-props-no-multi-spaces', rule, {
             console.log(value);
           }}
 
+          type="button"
+        />
+      `,
+      output: `
+        <button
+          title="Some button"
+          onClick={(value) => {
+            console.log(value);
+          }}
           type="button"
         />
       `,
@@ -306,6 +321,16 @@ ruleTester.run('jsx-props-no-multi-spaces', rule, {
             type="button"
           />
         `,
+        output: `
+          <button
+            title="Some button"
+            // this is a comment
+            onClick={(value) => {
+              console.log(value);
+            }}
+            type="button"
+          />
+        `,
         errors: [
           {
             messageId: 'noLineGap',
@@ -324,6 +349,17 @@ ruleTester.run('jsx-props-no-multi-spaces', rule, {
               console.log(value);
             }}
 
+            type="button"
+          />
+        `,
+        output: `
+          <button
+            title="Some button"
+            // this is a comment
+            // second comment
+            onClick={(value) => {
+              console.log(value);
+            }}
             type="button"
           />
         `,
@@ -351,6 +387,19 @@ ruleTester.run('jsx-props-no-multi-spaces', rule, {
               console.log(value);
             }}
 
+            type="button"
+          />
+        `,
+        output: `
+          <button
+            title="Some button"
+            /*this is a
+              multiline
+              comment
+            */
+            onClick={(value) => {
+              console.log(value);
+            }}
             type="button"
           />
         `,


### PR DESCRIPTION
Extends automatic fix support to cover the "no line gap" half of the `jsx-props-no-multi-spaces` rule. There is already automatic fix support for the "only one space" enforcement.

Initially tagging as a `[Fix]` because it was unexpected that the rule does not fix line gaps when the rule is stated to be automatically fixable in the docs.