### PR TITLE
Fix ESLint v10 RuleContext API removal (follow-up to #3972)

### DIFF
--- a/.github/workflows/eslint-9+.yml
+++ b/.github/workflows/eslint-9+.yml
@@ -26,6 +26,7 @@ jobs:
       matrix:
         node-version: ${{ fromJson(needs.matrix.outputs.latest) }}
         eslint:
+          - 10
           - 9
         babel-eslint:
           - 10
@@ -33,6 +34,14 @@ jobs:
           - 8
         typescript-eslint:
           - 8
+        exclude:
+          # ESLint 10 supports Node.js 20+.
+          - eslint: 10
+            node-version: 18
+          - eslint: 10
+            node-version: 19
+          - eslint: 10
+            babel-eslint: 8
 
     steps:
       - uses: actions/checkout@v4
@@ -41,7 +50,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           after_install: |
-            npm install --no-save "eslint@${{ matrix.eslint }}" "@typescript-eslint/parser@${{ matrix.typescript-eslint == 8 && 8.17 || matrix.typescript-eslint }}" "babel-eslint@${{ matrix.babel-eslint }}"
+            npm install --no-save "eslint@${{ matrix.eslint }}" "@typescript-eslint/parser@${{ matrix.eslint == 10 && 'canary' || (matrix.typescript-eslint == 8 && 8.17 || matrix.typescript-eslint) }}" "babel-eslint@${{ matrix.babel-eslint }}" ${{ matrix.eslint == 10 && '"typescript@5"' || '' }}
           skip-ls-check: true
       - run: npx ls-engines
       - run: npm run unit-test

--- a/.github/workflows/type-check.yml
+++ b/.github/workflows/type-check.yml
@@ -16,6 +16,7 @@ jobs:
           - '7'
           - '8'
           - '9'
+          - '10'
         ts_version:
           # The official ESLint types are not compatible with TS 3.9
           # - 3.9
@@ -34,7 +35,7 @@ jobs:
           - es2020
           - esnext
         exclude:
-          # ESLint 9 ships types via @eslint/core which requires TS >= 5.0
+          # ESLint 9+ ships types via @eslint/core which requires TS >= 5.0
           - eslint_version: '9'
             ts_version: '4.0'
           - eslint_version: '9'
@@ -46,6 +47,18 @@ jobs:
           - eslint_version: '9'
             ts_version: 4.4
           - eslint_version: '9'
+            ts_version: 4.5
+          - eslint_version: '10'
+            ts_version: '4.0'
+          - eslint_version: '10'
+            ts_version: 4.1
+          - eslint_version: '10'
+            ts_version: 4.2
+          - eslint_version: '10'
+            ts_version: 4.3
+          - eslint_version: '10'
+            ts_version: 4.4
+          - eslint_version: '10'
             ts_version: 4.5
     steps:
       - uses: actions/checkout@v4
@@ -61,7 +74,12 @@ jobs:
 
       - name: select eslint types
         run: |
-          if [ "${{ matrix.eslint_version }}" = "9" ]; then
+          if [ "${{ matrix.eslint_version }}" = "10" ]; then
+            # Avoid dev dependency peer conflicts with eslint@10.
+            npm prune --omit=dev
+            npm uninstall --no-save @types/eslint
+            npm install --no-save --legacy-peer-deps eslint@^10 typescript@^5
+          elif [ "${{ matrix.eslint_version }}" = "9" ]; then
             npm uninstall --no-save @types/eslint
             npm install --no-save eslint@^9 typescript@^5
           elif [ "${{ matrix.eslint_version }}" = "7" ]; then

--- a/lib/util/makeNoMethodSetStateRule.js
+++ b/lib/util/makeNoMethodSetStateRule.js
@@ -51,14 +51,16 @@ function shouldBeNoop(context, methodName) {
  * @returns {import('eslint').Rule.RuleModule}
  */
 module.exports = function makeNoMethodSetStateRule(methodName, shouldCheckUnsafeCb) {
+  const docs = {
+    description: `Disallow usage of setState in ${methodName}`,
+    category: 'Best Practices',
+    recommended: false,
+    url: docsUrl(mapTitle(methodName)),
+  };
+
   return {
     meta: {
-      docs: {
-        description: `Disallow usage of setState in ${methodName}`,
-        category: 'Best Practices',
-        recommended: false,
-        url: docsUrl(mapTitle(methodName)),
-      },
+      docs,
 
       messages,
 

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@types/node": "^4.9.5",
     "@typescript-eslint/parser": "^2.34.0 || ^3.10.1 || ^4 || ^5 || ^6.20 || ^7.14.1 || 8.4 - 8.17",
     "babel-eslint": "^8 || ^9 || ^10.1.0",
-    "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7",
+    "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7 || ^10",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-doc-generator": "^3.3.2",
     "eslint-plugin-eslint-plugin": "^2.3.0 || ^3.5.3 || ^4.0.1 || ^5.0.5",
@@ -89,7 +89,7 @@
     "typescript-eslint-parser": "^20.1.1"
   },
   "peerDependencies": {
-    "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
+    "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7 || ^10"
   },
   "engines": {
     "node": ">=4"


### PR DESCRIPTION
This PR follows up on the feedback in the comments of https://github.com/jsx-eslint/eslint-plugin-react/pull/3972 and incorporates the requested changes.

I think this PR will fix #3977.