### PR TITLE
docs: fix self-closing component examples

### DIFF
--- a/docs/rules/self-closing-comp.md
+++ b/docs/rules/self-closing-comp.md
@@ -13,6 +13,8 @@ Components without children can be self-closed to avoid unnecessary extra closin
 Examples of **incorrect** code for this rule:
 
 ```jsx
+var contentContainer = <div className="content"></div>;
+
 var HelloJohn = <Hello name="John"></Hello>;
 
 var HelloJohnCompound = <Hello.Compound name="John"></Hello.Compound>;
@@ -21,8 +23,6 @@ var HelloJohnCompound = <Hello.Compound name="John"></Hello.Compound>;
 Examples of **correct** code for this rule:
 
 ```jsx
-var contentContainer = <div className="content"></div>;
-
 var intentionalSpace = <div>{' '}</div>;
 
 var HelloJohn = <Hello name="John" />;


### PR DESCRIPTION
Closes #3852.

Moves the empty `<div></div>` example into the default incorrect examples. With the default `{ html: true }` option, the rule reports that form and requires `<div />`.

This documentation-only correction was AI-assisted, then validated against the rule defaults and runtime behavior and independently reviewed.

Validation:
- `npm run lint` (0 errors; 47 pre-existing warnings)
- focused `self-closing-comp` suite (235 passing)
- full unit suite on the supported ESLint 7 / parser 4 matrix (29,218 passing)
- runtime behavior probe
- `git diff --check`