### PR TITLE
fix: preserve comments in JSX closing bracket autofix

### DIFF
--- a/lib/rules/jsx-closing-bracket-location.js
+++ b/lib/rules/jsx-closing-bracket-location.js
@@ -149,7 +149,8 @@ module.exports = {
         case 'after-tag':
           return tokens.tag.line === tokens.closing.line;
         case 'after-props':
-          return tokens.lastProp.lastLine === tokens.closing.line;
+          return (tokens.lastComment ? tokens.lastComment.loc.end.line : tokens.lastProp.lastLine)
+            === tokens.closing.line;
         case 'props-aligned':
         case 'tag-aligned':
         case 'line-aligned': {
@@ -200,16 +201,22 @@ module.exports = {
     function getTokensLocations(node) {
       const sourceCode = getSourceCode(context);
       const opening = sourceCode.getFirstToken(node).loc.start;
-      const closing = sourceCode.getLastTokens(node, node.selfClosing ? 2 : 1)[0].loc.start;
+      const closingToken = sourceCode.getLastTokens(node, node.selfClosing ? 2 : 1)[0];
+      const closing = closingToken.loc.start;
       const tag = sourceCode.getFirstToken(node.name).loc.start;
       let lastProp;
+      let lastComment;
       if (node.attributes.length) {
-        lastProp = node.attributes[node.attributes.length - 1];
+        const lastAttribute = node.attributes[node.attributes.length - 1];
         lastProp = {
-          column: sourceCode.getFirstToken(lastProp).loc.start.column,
-          firstLine: sourceCode.getFirstToken(lastProp).loc.start.line,
-          lastLine: sourceCode.getLastToken(lastProp).loc.end.line,
+          column: sourceCode.getFirstToken(lastAttribute).loc.start.column,
+          firstLine: sourceCode.getFirstToken(lastAttribute).loc.start.line,
+          lastLine: sourceCode.getLastToken(lastAttribute).loc.end.line,
         };
+
+        const commentsAfterLastAttribute = sourceCode.getCommentsAfter(lastAttribute)
+          .filter((token) => token.range[1] <= closingToken.range[0]);
+        lastComment = commentsAfterLastAttribute[commentsAfterLastAttribute.length - 1];
       }
       const openingLine = sourceCode.lines[opening.line - 1];
       const closingLine = sourceCode.lines[closing.line - 1];
@@ -227,6 +234,7 @@ module.exports = {
         opening,
         closing,
         lastProp,
+        lastComment,
         selfClosing: node.selfClosing,
         openingStartOfLine,
       };
@@ -297,6 +305,16 @@ module.exports = {
                 return fixer.replaceTextRange([node.name.range[1], node.range[1]],
                   (expectedNextLine ? '\n' : ' ') + closingTag);
               case 'after-props':
+                if (tokens.lastComment) {
+                  if (tokens.lastComment.type === 'Line' && tokens.lastComment.value.includes('*/')) {
+                    return null;
+                  }
+                  const commentText = tokens.lastComment.type === 'Line'
+                    ? `/*${tokens.lastComment.value} */`
+                    : getSourceCode(context).getText(tokens.lastComment);
+                  return fixer.replaceTextRange([tokens.lastComment.range[0], node.range[1]],
+                    `${commentText} ${closingTag}`);
+                }
                 return fixer.replaceTextRange([cachedLastAttributeEndPos, node.range[1]],
                   (expectedNextLine ? '\n' : '') + closingTag);
               case 'props-aligned':

--- a/lib/rules/jsx-closing-bracket-location.js
+++ b/lib/rules/jsx-closing-bracket-location.js
@@ -217,6 +217,10 @@ module.exports = {
         const commentsAfterLastAttribute = sourceCode.getCommentsAfter(lastAttribute)
           .filter((token) => token.range[1] <= closingToken.range[0]);
         lastComment = commentsAfterLastAttribute[commentsAfterLastAttribute.length - 1];
+      } else {
+        const commentsAfterTag = sourceCode.getCommentsAfter(node.name)
+          .filter((token) => token.range[1] <= closingToken.range[0]);
+        lastComment = commentsAfterTag[commentsAfterTag.length - 1];
       }
       const openingLine = sourceCode.lines[opening.line - 1];
       const closingLine = sourceCode.lines[closing.line - 1];
@@ -298,6 +302,9 @@ module.exports = {
             const closingTag = tokens.selfClosing ? '/>' : '>';
             switch (expectedLocation) {
               case 'after-tag':
+                if (tokens.lastComment) {
+                  return null;
+                }
                 if (cachedLastAttributeEndPos) {
                   return fixer.replaceTextRange([cachedLastAttributeEndPos, node.range[1]],
                     (expectedNextLine ? '\n' : '') + closingTag);

--- a/tests/lib/rules/jsx-closing-bracket-location-comment-only.js
+++ b/tests/lib/rules/jsx-closing-bracket-location-comment-only.js
@@ -1,0 +1,59 @@
+/**
+ * @fileoverview Regression coverage for comment-only JSX opening elements
+ */
+
+'use strict';
+
+const RuleTester = require('../../helpers/ruleTester');
+const rule = require('../../../lib/rules/jsx-closing-bracket-location');
+
+const parsers = require('../../helpers/parsers');
+
+const parserOptions = {
+  ecmaVersion: 2018,
+  sourceType: 'module',
+  ecmaFeatures: {
+    jsx: true,
+  },
+};
+
+const ruleTester = new RuleTester({ parserOptions });
+ruleTester.run('jsx-closing-bracket-location comment-only elements', rule, {
+  valid: [],
+  invalid: parsers.all([
+    {
+      code: `
+        <App
+          // foo={bar}
+        />
+      `,
+      output: null,
+      errors: [
+        {
+          messageId: 'bracketLocation',
+          data: {
+            location: 'placed after the opening tag',
+            details: '',
+          },
+        },
+      ],
+    },
+    {
+      code: `
+        <App
+          // foo={bar}
+        ></App>
+      `,
+      output: null,
+      errors: [
+        {
+          messageId: 'bracketLocation',
+          data: {
+            location: 'placed after the opening tag',
+            details: '',
+          },
+        },
+      ],
+    },
+  ]),
+});

--- a/tests/lib/rules/jsx-closing-bracket-location.js
+++ b/tests/lib/rules/jsx-closing-bracket-location.js
@@ -446,6 +446,75 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     },
     {
       code: `
+        <App
+          foo
+          // baz */
+        />
+      `,
+      output: null,
+      options: [{ location: 'after-props' }],
+      errors: [
+        {
+          messageId: 'bracketLocation',
+          data: {
+            location: MESSAGE_AFTER_PROPS,
+            details: '',
+          },
+        },
+      ],
+    },
+    {
+      code: `
+        <App
+          foo
+          // bar
+          // baz
+        />
+      `,
+      output: `
+        <App
+          foo
+          // bar
+          /* baz */ />
+      `,
+      options: [{ location: 'after-props' }],
+      errors: [
+        {
+          messageId: 'bracketLocation',
+          data: {
+            location: MESSAGE_AFTER_PROPS,
+            details: '',
+          },
+        },
+      ],
+    },
+    {
+      code: `
+        <App
+          foo
+          // bar
+          // baz
+        ></App>
+      `,
+      output: `
+        <App
+          foo
+          // bar
+          /* baz */ ></App>
+      `,
+      options: [{ location: 'after-props' }],
+      errors: [
+        {
+          messageId: 'bracketLocation',
+          data: {
+            location: MESSAGE_AFTER_PROPS,
+            details: '',
+          },
+        },
+      ],
+    },
+    {
+      code: `
         <App foo
         ></App>
       `,


### PR DESCRIPTION
## Summary

Preserve comments after the final JSX attribute when `jsx-closing-bracket-location`
autofixes a closing bracket. The fixer now uses the last comment as the layout
anchor and preserves line comments safely, with regression cases for self-
closing and paired elements.

Fixes #3793.

## Validation

- focused suite: 505 passing
- full suite: 29,267 passing
- lint and type check
- `git diff --check`

## AI assistance

AI assistance was used for investigation and drafting. I reviewed the fixer,
comment-token handling, and complete snapshot/test diff, then independently
ran the focused and full suites.
