### PR TITLE
fix: preserve TypeScript comments in sort-prop-types autofix

### DIFF
--- a/lib/util/propTypesSort.js
+++ b/lib/util/propTypesSort.js
@@ -150,6 +150,8 @@ function fixPropTypesSort(
   function sortInSource(allNodes, source) {
     const originalSource = source;
     const sourceCode = getSourceCode(context);
+    const trailingCommentRanges = new Set();
+
     for (let i = 0; i < allNodes.length; i++) {
       const node = allNodes[i];
       let commentAfter = [];
@@ -157,8 +159,10 @@ function fixPropTypesSort(
       let newStart = 0;
       let newEnd = 0;
       try {
-        commentBefore = sourceCode.getCommentsBefore(node);
+        commentBefore = sourceCode.getCommentsBefore(node)
+          .filter((comment) => !trailingCommentRanges.has(comment.range.join(':')));
         commentAfter = sourceCode.getCommentsAfter(node);
+        commentAfter.forEach((comment) => trailingCommentRanges.add(comment.range.join(':')));
       } catch (e) { /**/ }
 
       if (commentAfter.length === 0 || commentBefore.length === 0) {
@@ -197,10 +201,7 @@ function fixPropTypesSort(
         const sortedAttr = sortedAttributes[index];
         const commentNode = commentnodeMap.get(sortedAttr);
         let sortedAttrText = sourceCodeText.slice(commentNode.start, commentNode.end);
-        const sortedAttrTextLastChar = sortedAttrText[sortedAttrText.length - 1];
-        if (!separator && [';', ','].some((allowedSep) => sortedAttrTextLastChar === allowedSep)) {
-          separator = sortedAttrTextLastChar;
-        }
+        let sortedAttrTextStart = commentNode.start;
         if (sortShapeProp && isShapeProp(sortedAttr.value)) {
           const shape = getShapeProperties(sortedAttr.value);
           if (shape) {
@@ -209,9 +210,20 @@ function fixPropTypesSort(
               originalSource
             );
             sortedAttrText = attrSource.slice(sortedAttr.range[0], sortedAttr.range[1]);
+            sortedAttrTextStart = sortedAttr.range[0];
           }
         }
-        const sortedAttrTextVal = checkTypes && !sortedAttrText.endsWith(separator) ? `${sortedAttrText}${separator}` : sortedAttrText;
+        const trailingComment = sourceCode.getCommentsAfter(sortedAttr)[0];
+        const separatorIndex = trailingComment ? trailingComment.range[0] - sortedAttrTextStart : sortedAttrText.length;
+        const sortedAttrTextLastChar = sortedAttrText.slice(0, separatorIndex).trim().slice(-1);
+        if (!separator && [';', ','].some((allowedSep) => sortedAttrTextLastChar === allowedSep)) {
+          separator = sortedAttrTextLastChar;
+        }
+        const hasSeparator = sortedAttrText.slice(0, separatorIndex).trim().endsWith(separator);
+        const needsSeparator = checkTypes && separator && !hasSeparator;
+        const sortedAttrTextVal = needsSeparator
+          ? `${sortedAttrText.slice(0, separatorIndex)}${separator}${sortedAttrText.slice(separatorIndex)}`
+          : sortedAttrText;
         return `${acc.slice(0, commentnodeMap.get(attr).start)}${sortedAttrTextVal}${acc.slice(commentnodeMap.get(attr).end)}`;
       }, source);
     });

--- a/lib/util/propTypesSort.js
+++ b/lib/util/propTypesSort.js
@@ -123,6 +123,25 @@ function sorter(a, b, context, ignoreCase, requiredFirst, callbacksLast, noSortA
 const commentnodeMap = new WeakMap(); // all nodes reference WeakMap for start and end range
 
 /**
+ * Returns comments that belong to the preceding declaration rather than the
+ * next declaration.
+ *
+ * @param {SourceCode} sourceCode The source code object.
+ * @param {ASTNode} node The declaration node.
+ * @returns {Array} The trailing comments for the declaration.
+ */
+function getTrailingComments(sourceCode, node) {
+  const comments = sourceCode.getCommentsAfter(node);
+  const nextToken = sourceCode.getTokenAfter(node);
+
+  if (nextToken && [',', ';', '}'].includes(nextToken.value)) {
+    return comments.filter((comment) => comment.range[1] <= nextToken.range[0]);
+  }
+
+  return comments.filter((comment) => comment.loc.start.line === node.loc.end.line);
+}
+
+/**
  * Fixes sort order of prop types.
  *
  * @param {Context} context the second element to compare.
@@ -161,7 +180,7 @@ function fixPropTypesSort(
       try {
         commentBefore = sourceCode.getCommentsBefore(node)
           .filter((comment) => !trailingCommentRanges.has(comment.range.join(':')));
-        commentAfter = sourceCode.getCommentsAfter(node);
+        commentAfter = getTrailingComments(sourceCode, node);
         commentAfter.forEach((comment) => trailingCommentRanges.add(comment.range.join(':')));
       } catch (e) { /**/ }
 
@@ -213,7 +232,7 @@ function fixPropTypesSort(
             sortedAttrTextStart = sortedAttr.range[0];
           }
         }
-        const trailingComment = sourceCode.getCommentsAfter(sortedAttr)[0];
+        const trailingComment = getTrailingComments(sourceCode, sortedAttr)[0];
         const separatorIndex = trailingComment ? trailingComment.range[0] - sortedAttrTextStart : sortedAttrText.length;
         const sortedAttrTextLastChar = sortedAttrText.slice(0, separatorIndex).trim().slice(-1);
         if (!separator && [';', ','].some((allowedSep) => sortedAttrTextLastChar === allowedSep)) {

--- a/tests/lib/rules/sort-prop-types.js
+++ b/tests/lib/rules/sort-prop-types.js
@@ -2316,6 +2316,84 @@ ruleTester.run('sort-prop-types', rule, {
     {
       code: `
         type Props = {
+          onClose: () => void; // closes the dialog
+          onSave?: () => void; // saves the dialog
+          id: string; // identifies the dialog
+        };
+        function Dialog(props: Props) {
+          return <div />;
+        }
+      `,
+      output: `
+        type Props = {
+          id: string; // identifies the dialog
+          onClose: () => void; // closes the dialog
+          onSave?: () => void; // saves the dialog
+        };
+        function Dialog(props: Props) {
+          return <div />;
+        }
+      `,
+      parser: parsers.TYPESCRIPT_ESLINT,
+      options: [{
+        callbacksLast: true,
+        noSortAlphabetically: true,
+        checkTypes: true,
+      }],
+      errors: [
+        {
+          messageId: 'callbackPropsLast',
+        },
+      ],
+    },
+    {
+      code: `
+        type Props = {
+          onClose: () => void;
+          onSave?: () => void;
+          initialContractInfo?: ContractInfo; // used to pre-populate the form just for our tests
+          contractVersionTraceId?: TraceId; // used when editing an existing contract
+          contractContainerId: TraceId;
+          wizardStartIndex?: number;
+          contractStatus?: BackendContractStatus;
+          contractVersion?: BackendContractVersion;
+        };
+        function ContractVersionWizard(props: Props) {
+          return <div />;
+        }
+      `,
+      output: `
+        type Props = {
+          initialContractInfo?: ContractInfo; // used to pre-populate the form just for our tests
+          contractVersionTraceId?: TraceId; // used when editing an existing contract
+          contractContainerId: TraceId;
+          wizardStartIndex?: number;
+          contractStatus?: BackendContractStatus;
+          contractVersion?: BackendContractVersion;
+          onClose: () => void;
+          onSave?: () => void;
+        };
+        function ContractVersionWizard(props: Props) {
+          return <div />;
+        }
+      `,
+      parser: parsers.TYPESCRIPT_ESLINT,
+      options: [{
+        callbacksLast: true,
+        requiredFirst: true,
+        sortShapeProp: true,
+        noSortAlphabetically: true,
+        checkTypes: true,
+      }],
+      errors: [
+        {
+          messageId: 'callbackPropsLast',
+        },
+      ],
+    },
+    {
+      code: `
+        type Props = {
           zzz: string;
           aaa: string;
         }

--- a/tests/lib/rules/sort-prop-types.js
+++ b/tests/lib/rules/sort-prop-types.js
@@ -2350,6 +2350,105 @@ ruleTester.run('sort-prop-types', rule, {
       code: `
         type Props = {
           onClose: () => void;
+          // identifies the dialog
+          id: string;
+        };
+        function Dialog(props: Props) {
+          return <div />;
+        }
+      `,
+      output: `
+        type Props = {
+          // identifies the dialog
+          id: string;
+          onClose: () => void;
+        };
+        function Dialog(props: Props) {
+          return <div />;
+        }
+      `,
+      parser: parsers.TYPESCRIPT_ESLINT,
+      options: [{
+        callbacksLast: true,
+        noSortAlphabetically: true,
+        checkTypes: true,
+      }],
+      errors: [
+        {
+          messageId: 'callbackPropsLast',
+        },
+      ],
+    },
+    {
+      code: `
+        type Props = {
+          onClose: () => void; // closes the dialog
+          // identifies the dialog
+          id: string;
+        };
+        function Dialog(props: Props) {
+          return <div />;
+        }
+      `,
+      output: `
+        type Props = {
+          // identifies the dialog
+          id: string;
+          onClose: () => void; // closes the dialog
+        };
+        function Dialog(props: Props) {
+          return <div />;
+        }
+      `,
+      parser: parsers.TYPESCRIPT_ESLINT,
+      options: [{
+        callbacksLast: true,
+        noSortAlphabetically: true,
+        checkTypes: true,
+      }],
+      errors: [
+        {
+          messageId: 'callbackPropsLast',
+        },
+      ],
+    },
+    {
+      code: `
+        type Props = {
+          onClose: () => void; /* closes the dialog */
+          /* identifies the dialog */
+          id: string;
+        };
+        function Dialog(props: Props) {
+          return <div />;
+        }
+      `,
+      output: `
+        type Props = {
+          /* identifies the dialog */
+          id: string;
+          onClose: () => void; /* closes the dialog */
+        };
+        function Dialog(props: Props) {
+          return <div />;
+        }
+      `,
+      parser: parsers.TYPESCRIPT_ESLINT,
+      options: [{
+        callbacksLast: true,
+        noSortAlphabetically: true,
+        checkTypes: true,
+      }],
+      errors: [
+        {
+          messageId: 'callbackPropsLast',
+        },
+      ],
+    },
+    {
+      code: `
+        type Props = {
+          onClose: () => void;
           onSave?: () => void;
           initialContractInfo?: ContractInfo; // used to pre-populate the form just for our tests
           contractVersionTraceId?: TraceId; // used when editing an existing contract


### PR DESCRIPTION
## Summary

Keep comments intact when `sort-prop-types` autofixes TypeScript code. The
sorter now preserves comment-bearing nodes while reordering the declarations,
with regression coverage for the reported invalid output.

Fixes #3794.

## Validation

- focused suite: 385 passing
- full suite: 29,258 passing
- lint and type check
- `git diff --check`

## AI assistance

AI assistance was used for investigation and drafting. I reviewed the sorting
and comment-preservation contracts and independently ran the focused and full
suites.
