### PR TITLE
docs: clarify hook-use-state setter naming

### DIFF
--- a/docs/rules/hook-use-state.md
+++ b/docs/rules/hook-use-state.md
@@ -10,7 +10,7 @@
 
 ## Rule Details
 
-This rule checks whether the value and setter variables destructured from a `React.useState()` call are named symmetrically.
+This rule checks whether the result of a `React.useState()` call, when assigned to a variable, is destructured into a value and setter pair, and whether those variables are named symmetrically.
 
 Examples of **incorrect** code for this rule:
 


### PR DESCRIPTION
## Summary

Clarify the `hook-use-state` documentation so the setter returned by
`useState` is described accurately, including the naming convention the rule
checks. The rule behavior is unchanged.

Fixes #3872.

## Validation

- focused suite: 221 passing
- Markdown lint and diff checks

## AI assistance

AI assistance was used for investigation and drafting. I reviewed the rule
documentation against the implementation and independently ran the checks.
