### PR TITLE
fix: support React component type aliases in prop-types

### DIFF
--- a/lib/util/propTypes.js
+++ b/lib/util/propTypes.js
@@ -525,15 +525,16 @@ module.exports = function propTypesInstructions(context, components, utils) {
   }
 
   function isValidReactGenericTypeAnnotation(annotation) {
-    if (annotation.typeName) {
-      if (annotation.typeName.name) { // if FC<Props>
-        const typeName = annotation.typeName.name;
+    const typeNameNode = annotation.typeName || annotation.expression || annotation.id;
+    if (typeNameNode) {
+      if (typeNameNode.name) { // if FC<Props>
+        const typeName = typeNameNode.name;
         if (!genericReactTypesImport.has(typeName)) {
           return false;
         }
-      } else if (annotation.typeName.right.name) { // if React.FC<Props>
-        const right = annotation.typeName.right.name;
-        const left = annotation.typeName.left.name;
+      } else if (typeNameNode.right && typeNameNode.right.name) { // if React.FC<Props>
+        const right = typeNameNode.right.name;
+        const left = typeNameNode.left.name;
 
         if (!genericReactTypesImport.has(left) || !allowedGenericTypes.has(right)) {
           return false;
@@ -541,6 +542,48 @@ module.exports = function propTypesInstructions(context, components, utils) {
       }
     }
     return true;
+  }
+
+  function isReactGenericTypeAnnotation(annotation) {
+    return !!(
+      annotation
+      && (
+        astUtil.isTSTypeReference(annotation)
+        || astUtil.isTSInterfaceHeritage(annotation)
+      )
+      && propsUtil.getTypeArguments(annotation)
+      && isValidReactGenericTypeAnnotation(annotation)
+    );
+  }
+
+  function isReactComponentTypeAlias(annotation) {
+    if (!astUtil.isTSTypeReference(annotation) || !annotation.typeName.name) {
+      return false;
+    }
+
+    const typeName = annotation.typeName.name;
+    return getSourceCode(context).ast.body.some((node) => {
+      const declaration = node.declaration || node;
+      if (!declaration.id || declaration.id.name !== typeName) {
+        return false;
+      }
+
+      if (astUtil.isTSInterfaceDeclaration(declaration)) {
+        const heritage = declaration.extends || declaration.heritage;
+        return heritage && heritage.some(isReactGenericTypeAnnotation);
+      }
+
+      if (astUtil.isTSTypeAliasDeclaration(declaration)) {
+        const typeAnnotation = declaration.typeAnnotation;
+        return isReactGenericTypeAnnotation(typeAnnotation)
+          || (
+            astUtil.isTSIntersectionType(typeAnnotation)
+            && typeAnnotation.types.some(isReactGenericTypeAnnotation)
+          );
+      }
+
+      return false;
+    });
   }
 
   /**
@@ -639,9 +682,16 @@ module.exports = function propTypesInstructions(context, components, utils) {
      */
     searchDeclarationByName(node) {
       let typeName;
+      let typeNameNode;
       if (astUtil.isTSTypeReference(node)) {
-        typeName = node.typeName.name;
-        const leftMostName = getLeftMostTypeName(node.typeName);
+        typeNameNode = node.typeName;
+      } else if (astUtil.isTSInterfaceHeritage(node)) {
+        typeNameNode = node.expression || node.id;
+      }
+
+      if (typeNameNode) {
+        typeName = typeNameNode.name;
+        const leftMostName = getLeftMostTypeName(typeNameNode);
         const shouldTraverseTypeParams = genericReactTypesImport.has(leftMostName);
         const nodeTypeArguments = propsUtil.getTypeArguments(node);
         if (shouldTraverseTypeParams && nodeTypeArguments && nodeTypeArguments.length !== 0) {
@@ -650,7 +700,7 @@ module.exports = function propTypesInstructions(context, components, utils) {
           // So we should construct an optional children prop
           this.shouldSpecifyOptionalChildrenProps = true;
 
-          const rightMostName = getRightMostTypeName(node.typeName);
+          const rightMostName = getRightMostTypeName(typeNameNode);
           if (
             leftMostName === 'React'
             && (
@@ -669,12 +719,6 @@ module.exports = function propTypesInstructions(context, components, utils) {
           const nextNode = nodeTypeArguments.params[idx];
           this.visitTSNode(nextNode);
           return;
-        }
-      } else if (astUtil.isTSInterfaceHeritage(node)) {
-        if (!node.expression && node.id) {
-          typeName = node.id.name;
-        } else {
-          typeName = node.expression.name;
         }
       }
       if (!typeName) {
@@ -1107,16 +1151,26 @@ module.exports = function propTypesInstructions(context, components, utils) {
     } else {
       // implements what's discussed here: https://github.com/jsx-eslint/eslint-plugin-react/issues/2777#issuecomment-683944481
       const annotation = siblingIdentifier.typeAnnotation.typeAnnotation;
+      const genericIntersectionType = astUtil.isTSIntersectionType(annotation)
+        && annotation.types.find((type) => (
+          astUtil.isTSTypeReference(type)
+          && propsUtil.getTypeArguments(type) != null
+          && isValidReactGenericTypeAnnotation(type)
+        ));
+      const genericAnnotation = genericIntersectionType || annotation;
 
       if (
-        annotation
-        && annotation.type !== 'TSTypeReference'
-        && propsUtil.getTypeArguments(annotation) == null
+        genericAnnotation
+        && genericAnnotation.type !== 'TSTypeReference'
+        && propsUtil.getTypeArguments(genericAnnotation) == null
       ) {
         return;
       }
 
-      if (!isValidReactGenericTypeAnnotation(annotation)) return;
+      if (
+        !isValidReactGenericTypeAnnotation(genericAnnotation)
+        && !isReactComponentTypeAlias(annotation)
+      ) return;
 
       markPropTypesAsDeclared(node, resolveTypeAnnotation(siblingIdentifier), rootNode);
     }

--- a/tests/lib/rules/prop-types.js
+++ b/tests/lib/rules/prop-types.js
@@ -3302,6 +3302,51 @@ ruleTester.run('prop-types', rule, {
       features: ['ts', 'no-babel'],
     },
     {
+      // issue: https://github.com/jsx-eslint/eslint-plugin-react/issues/3159
+      code: `
+        import { FC } from 'react';
+
+        interface BlockProps {
+          title: string;
+        }
+
+        interface ColumnsProps {
+          label: string;
+        }
+
+        const Block: FC<BlockProps> = ({ title }) => <div>{title}</div>;
+
+        interface ColumnsComponent extends FC<ColumnsProps> {
+          Block: typeof Block;
+        }
+
+        const Columns: ColumnsComponent = ({ label }) => <section>{label}</section>;
+        Columns.Block = Block;
+      `,
+      features: ['ts', 'no-babel'],
+    },
+    {
+      // issue: https://github.com/jsx-eslint/eslint-plugin-react/issues/3159
+      code: `
+        import { FC } from 'react';
+
+        interface BlockProps {
+          title: string;
+        }
+
+        interface ColumnsProps {
+          label: string;
+        }
+
+        const Block: FC<BlockProps> = ({ title }) => <div>{title}</div>;
+        const Columns: FC<ColumnsProps> & { Block: typeof Block } = ({ label }) => (
+          <section>{label}</section>
+        );
+        Columns.Block = Block;
+      `,
+      features: ['ts', 'no-babel'],
+    },
+    {
       code: `
         import type { FC } from 'react';
         type PersonProps = {


### PR DESCRIPTION
## Summary

Avoid the `react/prop-types` false positive for a component type alias that
extends a generic React component type. The TypeScript type analysis now
follows the alias and preserves the existing behavior for ordinary generic
annotations.

Fixes #3159.

## Validation

- focused suite: 1,128 passing
- full suite: 17,872 passing
- target lint and type check under Node 20

## AI assistance

AI assistance was used for investigation and drafting. I reviewed the
TypeScript type-resolution contract and independently ran the focused and full
suites.
