### PR TITLE
fix: preserve whitespace around empty JSX expressions

### DIFF
--- a/lib/rules/jsx-curly-brace-presence.js
+++ b/lib/rules/jsx-curly-brace-presence.js
@@ -86,7 +86,22 @@ function containsWhitespaceExpression(child) {
 }
 
 function isEmptyStringExpression(child) {
-  return child.type === 'JSXExpressionContainer' && child.expression.value === '';
+  if (child.type !== 'JSXExpressionContainer') {
+    return false;
+  }
+
+  const expression = child.expression;
+  if (expression.value === '') {
+    return true;
+  }
+
+  return (
+    expression.type === 'TemplateLiteral'
+    && expression.expressions.length === 0
+    && expression.quasis.length === 1
+    && expression.quasis[0].value.cooked === ''
+    && expression.quasis[0].value.raw === ''
+  );
 }
 
 function isLineBreak(text) {

--- a/lib/rules/jsx-curly-brace-presence.js
+++ b/lib/rules/jsx-curly-brace-presence.js
@@ -357,6 +357,10 @@ module.exports = {
       return adjSiblings.some((x) => x.type && arrayIncludes(['JSXExpressionContainer', 'JSXElement'], x.type));
     }
     function emptyStringExpressionPreservesWhitespace(node, children) {
+      if (!children) {
+        return false;
+      }
+
       const nodeIndex = children.indexOf(node);
       const previous = children[nodeIndex - 1];
       const next = children[nodeIndex + 1];

--- a/lib/rules/jsx-curly-brace-presence.js
+++ b/lib/rules/jsx-curly-brace-presence.js
@@ -85,6 +85,10 @@ function containsWhitespaceExpression(child) {
   return false;
 }
 
+function isEmptyStringExpression(child) {
+  return child.type === 'JSXExpressionContainer' && child.expression.value === '';
+}
+
 function isLineBreak(text) {
   return containsLineTerminators(text) && text.trim() === '';
 }
@@ -337,6 +341,22 @@ module.exports = {
 
       return adjSiblings.some((x) => x.type && arrayIncludes(['JSXExpressionContainer', 'JSXElement'], x.type));
     }
+    function emptyStringExpressionPreservesWhitespace(node, children) {
+      const nodeIndex = children.indexOf(node);
+      const previous = children[nodeIndex - 1];
+      const next = children[nodeIndex + 1];
+
+      return (
+        isEmptyStringExpression(node)
+        && previous
+        && next
+        && previous.type === 'JSXText'
+        && containsLineTerminators(previous.value)
+        && next.type === 'JSXText'
+        && /^\s/.test(next.value)
+        && hasAdjacentJsx(node, children.filter((child) => child !== previous))
+      );
+    }
     function shouldCheckForUnnecessaryCurly(node, config) {
       const parent = node.parent;
       // Bail out if the parent is a JSXAttribute & its contents aren't
@@ -359,6 +379,9 @@ module.exports = {
         return false;
       }
       if (containsWhitespaceExpression(node) && hasAdjacentJsx(node, parent.children)) {
+        return false;
+      }
+      if (emptyStringExpressionPreservesWhitespace(node, parent.children)) {
         return false;
       }
       if (

--- a/tests/lib/rules/jsx-curly-brace-presence-empty-template.js
+++ b/tests/lib/rules/jsx-curly-brace-presence-empty-template.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const RuleTester = require('../../helpers/ruleTester');
+const rule = require('../../../lib/rules/jsx-curly-brace-presence');
+
+const parserOptions = {
+  sourceType: 'module',
+  ecmaVersion: 2015,
+  ecmaFeatures: {
+    jsx: true,
+  },
+};
+
+const ruleTester = new RuleTester({ parserOptions });
+
+ruleTester.run('jsx-curly-brace-presence empty template literal whitespace', rule, {
+  valid: [
+    {
+      code: '<span>\n  <span>The braces</span>\n  {``} matter here.\n</span>',
+      options: [{ children: 'never' }],
+    },
+  ],
+  invalid: [
+    {
+      code: '<span><span>The braces</span>{``}matter here.</span>',
+      options: [{ children: 'never' }],
+      output: '<span><span>The braces</span>matter here.</span>',
+      errors: [{ messageId: 'unnecessaryCurly' }],
+    },
+  ],
+});

--- a/tests/lib/rules/jsx-curly-brace-presence-empty-template.js
+++ b/tests/lib/rules/jsx-curly-brace-presence-empty-template.js
@@ -22,6 +22,12 @@ ruleTester.run('jsx-curly-brace-presence empty template literal whitespace', rul
   ],
   invalid: [
     {
+      code: '<App prop={`foo`} />',
+      options: [{ props: 'never' }],
+      output: '<App prop="foo" />',
+      errors: [{ messageId: 'unnecessaryCurly' }],
+    },
+    {
       code: '<span><span>The braces</span>{``}matter here.</span>',
       options: [{ children: 'never' }],
       output: '<span><span>The braces</span>matter here.</span>',

--- a/tests/lib/rules/jsx-curly-brace-presence.js
+++ b/tests/lib/rules/jsx-curly-brace-presence.js
@@ -95,6 +95,16 @@ ruleTester.run('jsx-curly-brace-presence', rule, {
     },
     {
       code: `
+        <span>
+          <span>The braces</span>
+          {""} matter here.
+        </span>
+      `,
+      features: ['no-ts-new', 'no-ts-old'],
+      options: [{ children: 'never' }],
+    },
+    {
+      code: `
         <>
           foo{' '}
           <span>bar</span>
@@ -481,6 +491,13 @@ ruleTester.run('jsx-curly-brace-presence', rule, {
   )),
 
   invalid: parsers.all([].concat(
+    {
+      code: '<span><span>The braces</span>{""}matter here.</span>',
+      features: ['no-ts-new', 'no-ts-old'],
+      options: [{ children: 'never' }],
+      output: '<span><span>The braces</span>matter here.</span>',
+      errors: [{ messageId: 'unnecessaryCurly' }],
+    },
     {
       code: '<App prop={`foo`} />',
       options: [{ props: 'never' }],


### PR DESCRIPTION
## Summary

- Preserve an empty JSX expression when removing it would change whitespace across a multiline JSX boundary.
- Keep the existing removal behavior for inline empty expressions where no rendered whitespace is lost.
- Add the reported regression and a safe inline control case.

Fixes #3995.

## Validation

- `npx mocha tests/lib/rules/jsx-curly-brace-presence.js --grep 'The braces'` (`2` passing)
- Direct ESLint `Linter` verification of the reported case and inline control
- `npx eslint lib/rules/jsx-curly-brace-presence.js tests/lib/rules/jsx-curly-brace-presence.js` (0 errors; 7 pre-existing warnings in the test file)
- `git diff --check`

The full legacy parser matrix is not a reliable signal in this environment because its TypeScript 3.9 parser stack is incompatible with the installed Node 25 runtime; the focused rule tests and direct behavior checks pass.

Assisted-by: OpenAI Codex. The contributor reviewed the implementation and validation before publication.
