### PR TITLE
fix(no-children-prop): report a function child when the JSX spans lines

### DIFF
--- a/lib/rules/no-children-prop.js
+++ b/lib/rules/no-children-prop.js
@@ -40,6 +40,15 @@ function isLineBreak(node) {
   return isLiteral && isMultiline && isWhiteSpaces;
 }
 
+/**
+ * Checks if the node is a JSX comment, which renders nothing.
+ * @param {ASTNode} node - The AST node being checked.
+ * @returns {boolean} - True if node is a JSX comment, false if not.
+ */
+function isJSXComment(node) {
+  return node.type === 'JSXExpressionContainer' && node.expression.type === 'JSXEmptyExpression';
+}
+
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
@@ -125,7 +134,7 @@ module.exports = {
         }
       },
       JSXElement(node) {
-        const children = node.children && node.children.filter((child) => !isLineBreak(child));
+        const children = node.children && node.children.filter((child) => !isLineBreak(child) && !isJSXComment(child));
         if (children && children.length === 1 && children[0].type === 'JSXExpressionContainer') {
           if (isFunction(children[0].expression)) {
             report(context, messages.nestFunction, 'nestFunction', {

--- a/lib/rules/no-children-prop.js
+++ b/lib/rules/no-children-prop.js
@@ -7,6 +7,7 @@
 
 const docsUrl = require('../util/docsUrl');
 const isCreateElement = require('../util/isCreateElement');
+const jsxUtil = require('../util/jsx');
 const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
@@ -24,6 +25,19 @@ function isCreateElementWithProps(node, context) {
   return isCreateElement(context, node)
     && node.arguments.length > 1
     && node.arguments[1].type === 'ObjectExpression';
+}
+
+/**
+ * Checks if the node is a line break, which JSX ignores.
+ * @param {ASTNode} node - The AST node being checked.
+ * @returns {boolean} - True if node is a line break, false if not.
+ */
+function isLineBreak(node) {
+  const isLiteral = node.type === 'Literal' || node.type === 'JSXText';
+  const isMultiline = node.loc.start.line !== node.loc.end.line;
+  const isWhiteSpaces = jsxUtil.isWhiteSpaces(node.value);
+
+  return isLiteral && isMultiline && isWhiteSpaces;
 }
 
 // ------------------------------------------------------------------------------
@@ -111,7 +125,7 @@ module.exports = {
         }
       },
       JSXElement(node) {
-        const children = node.children;
+        const children = node.children && node.children.filter((child) => !isLineBreak(child));
         if (children && children.length === 1 && children[0].type === 'JSXExpressionContainer') {
           if (isFunction(children[0].expression)) {
             report(context, messages.nestFunction, 'nestFunction', {

--- a/tests/lib/rules/no-children-prop.js
+++ b/tests/lib/rules/no-children-prop.js
@@ -172,6 +172,25 @@ ruleTester.run('no-children-prop', rule, {
       code: 'React.createElement(MyComponent, {children: function* () {}});',
       options: [{ allowFunctions: true }],
     },
+    {
+      code: '<MyComponent>\n  {data}\n</MyComponent>;',
+      options: [{ allowFunctions: true }],
+    },
+    {
+      code: '<MyComponent>\n  Text\n  {() => {}}\n</MyComponent>;',
+      options: [{ allowFunctions: true }],
+    },
+    {
+      code: '<MyComponent>\n  {() => {}}\n  {() => {}}\n</MyComponent>;',
+      options: [{ allowFunctions: true }],
+    },
+    {
+      code: '<MyComponent> {() => {}}</MyComponent>;',
+      options: [{ allowFunctions: true }],
+    },
+    {
+      code: '<MyComponent>\n  {() => {}}\n</MyComponent>;',
+    },
   ]),
   invalid: parsers.all([
     {
@@ -251,6 +270,26 @@ ruleTester.run('no-children-prop', rule, {
     },
     {
       code: '<MyComponent>{function* () {}}</MyComponent>;',
+      options: [{ allowFunctions: true }],
+      errors: [{ messageId: 'nestFunction' }],
+    },
+    {
+      code: '<MyComponent>\n  {data => data.value}\n</MyComponent>;',
+      options: [{ allowFunctions: true }],
+      errors: [{ messageId: 'nestFunction' }],
+    },
+    {
+      code: '<MyComponent>\n  {() => {}}</MyComponent>;',
+      options: [{ allowFunctions: true }],
+      errors: [{ messageId: 'nestFunction' }],
+    },
+    {
+      code: '<MyComponent>{() => {}}\n</MyComponent>;',
+      options: [{ allowFunctions: true }],
+      errors: [{ messageId: 'nestFunction' }],
+    },
+    {
+      code: '<MyComponent>\n  {function() {}}\n</MyComponent>;',
       options: [{ allowFunctions: true }],
       errors: [{ messageId: 'nestFunction' }],
     },

--- a/tests/lib/rules/no-children-prop.js
+++ b/tests/lib/rules/no-children-prop.js
@@ -279,6 +279,11 @@ ruleTester.run('no-children-prop', rule, {
       errors: [{ messageId: 'nestFunction' }],
     },
     {
+      code: '<MyComponent>\n  {/* a comment */}\n  {() => {}}\n</MyComponent>;',
+      options: [{ allowFunctions: true }],
+      errors: [{ messageId: 'nestFunction' }],
+    },
+    {
       code: '<MyComponent>\n  {() => {}}</MyComponent>;',
       options: [{ allowFunctions: true }],
       errors: [{ messageId: 'nestFunction' }],


### PR DESCRIPTION
Fixes #4005.

The issue's one-line example actually does report. Run through the repo's own RuleTester with `allowFunctions: true`, `<MyComponent>{data => data.value}</MyComponent>` errors with nestFunction as documented. What stays silent is the same code with a newline anywhere inside the tags:

```jsx
<MyComponent>
  {data => data.value}
</MyComponent>
```

Multi-line JSX puts whitespace-only JSXText nodes around the expression, so `node.children` has length 3 and the `children.length === 1` guard in the JSXElement handler never matches. The rule only fired on the single-line form, which is not how most of this gets written.

The fix filters out line-break children (whitespace-only JSXText spanning multiple lines) before applying the guard, the same test no-danger-with-children uses (isLineBreak, built on jsxUtil.isWhiteSpaces). That matches JSX semantics: the transform drops whitespace containing a newline, but a plain space on one line is a real child. `<MyComponent> {() => {}}</MyComponent>` therefore stays silent, and a valid case pins that.

Since this widens what the rule reports, I checked what newly errors: only an element whose children are a lone function expression once line breaks are ignored, which is the documented warning case. New valid cases cover a non-function expression child and mixed text and function children. Two function children stay silent too, as does the multi-line form without allowFunctions.

Tests: 204 passing on the unmodified tree, 231 with the patch. The four new invalid cases fail without the rule change (12 failures across the default and both TypeScript parsers) and pass with it. Lint is clean on both changed files.
