### PR TITLE
fix(prop-types): do not treat an inline callback's own props parameter as component props

### DIFF
--- a/lib/util/usedPropTypes.js
+++ b/lib/util/usedPropTypes.js
@@ -10,6 +10,7 @@ const astUtil = require('./ast');
 const componentUtil = require('./componentUtil');
 const testReactVersion = require('./version').testReactVersion;
 const eslintUtil = require('./eslint');
+const getVariable = require('./variable').getVariable;
 
 const getScope = eslintUtil.getScope;
 const getSourceCode = eslintUtil.getSourceCode;
@@ -78,6 +79,60 @@ function isCommonVariableNameForProps(name) {
  */
 function mustBeValidated(component) {
   return !!(component && !component.ignorePropsValidation);
+}
+
+/**
+ * Checks if the given name, resolved from the node's scope, is the parameter of an
+ * inline callback: a function that is not itself a component and is passed directly
+ * as a call argument or a JSX attribute value. Such a parameter receives whatever
+ * the callee passes and is never the component's props, whatever it is named.
+ * @param {Context} context
+ * @param {ASTNode} node The AST node the name is used in.
+ * @param {string} name The variable name to resolve.
+ * @param {Object} utils
+ * @returns {boolean} True if the name is an inline callback's own parameter.
+ */
+function isParamOfInlineCallback(context, node, name, utils) {
+  if (typeof name !== 'string') {
+    return false;
+  }
+  let scope = getScope(context, node);
+  let variable;
+  while (scope && !variable) {
+    variable = getVariable(scope.variables, name);
+    scope = scope.upper;
+  }
+  if (!variable || variable.defs.length === 0) {
+    return false;
+  }
+  const def = variable.defs[variable.defs.length - 1];
+  if (def.type !== 'Parameter') {
+    return false;
+  }
+  const fn = def.node;
+  if (utils.getStatelessComponent(fn)) {
+    return false;
+  }
+  let child = fn;
+  let parent = fn.parent;
+  while (
+    parent && (
+      parent.type === 'ObjectExpression'
+      || parent.type === 'ArrayExpression'
+      || parent.type === 'JSXExpressionContainer'
+      || (parent.type === 'Property' && parent.value === child)
+    )
+  ) {
+    child = parent;
+    parent = parent.parent;
+  }
+  if (!parent) {
+    return false;
+  }
+  if (astUtil.isCallExpression(parent) || parent.type === 'NewExpression') {
+    return parent.arguments.indexOf(child) !== -1;
+  }
+  return parent.type === 'JSXAttribute';
 }
 
 /**
@@ -259,7 +314,9 @@ function isPropTypesUsageByMemberExpression(context, node, utils, checkAsyncSafe
     return false;
   }
   // props.* in function component
-  return unwrappedObjectNode.name === 'props' && !astUtil.isAssignmentLHS(node);
+  return unwrappedObjectNode.name === 'props'
+    && !astUtil.isAssignmentLHS(node)
+    && !isParamOfInlineCallback(context, node, unwrappedObjectNode.name, utils);
 }
 
 /**
@@ -510,7 +567,13 @@ module.exports = function usedPropTypesInstructions(context, components, utils) 
       // let {firstname} = props
       if (
         isCommonVariableNameForProps(unwrappedInitNode.name)
-        && (utils.getParentStatelessComponent(node) || isInLifeCycleMethod(node, checkAsyncSafeLifeCycles))
+        && (
+          (
+            utils.getParentStatelessComponent(node)
+            && !isParamOfInlineCallback(context, node, unwrappedInitNode.name, utils)
+          )
+          || isInLifeCycleMethod(node, checkAsyncSafeLifeCycles)
+        )
       ) {
         markPropTypesAsUsed(node.id);
         return;

--- a/tests/lib/rules/prop-types.js
+++ b/tests/lib/rules/prop-types.js
@@ -4993,6 +4993,53 @@ ruleTester.run('prop-types', rule, {
         );
       `,
       features: ['types'],
+    },
+    {
+      code: `
+        function Comp({ episodeId }) {
+          const query = useQuery({ id: episodeId }, { select: (props) => props.isError ? null : props });
+          return <div>{query}</div>;
+        }
+        Comp.propTypes = {
+          episodeId: PropTypes.string,
+        };
+      `,
+    },
+    {
+      code: `
+        function Comp({ episodeId }) {
+          const query = useQuery({ id: episodeId }, {
+            select: (props) => {
+              const { isError } = props;
+              return isError;
+            },
+          });
+          return <div>{query}</div>;
+        }
+        Comp.propTypes = {
+          episodeId: PropTypes.string,
+        };
+      `,
+    },
+    {
+      code: `
+        function Comp({ items }) {
+          return <List data={items} renderItem={(props) => <div>{props.label}</div>} />;
+        }
+        Comp.propTypes = {
+          items: PropTypes.array,
+        };
+      `,
+    },
+    {
+      code: `
+        function Comp({ ids }) {
+          return <div>{ids.map((props) => props.value)}</div>;
+        }
+        Comp.propTypes = {
+          ids: PropTypes.array,
+        };
+      `,
     }
   )),
 
@@ -9113,6 +9160,48 @@ ruleTester.run('prop-types', rule, {
         {
           messageId: 'missingPropType',
           data: { name: 'prop$.events.map' },
+        },
+      ],
+    },
+    {
+      code: `
+        function Comp(props) {
+          const onClick = () => props.missing;
+          return <div onClick={onClick} />;
+        }
+        Comp.propTypes = {};
+      `,
+      errors: [
+        {
+          messageId: 'missingPropType',
+          data: { name: 'missing' },
+        },
+      ],
+    },
+    {
+      code: `
+        function Comp(props) {
+          const renderHeader = (props) => <h1>{props.title}</h1>;
+          return <div>{renderHeader(props)}</div>;
+        }
+        Comp.propTypes = {};
+      `,
+      errors: [
+        {
+          messageId: 'missingPropType',
+          data: { name: 'title' },
+        },
+      ],
+    },
+    {
+      code: `
+        const Comp = React.memo((props) => <div>{props.missing}</div>);
+        Comp.propTypes = {};
+      `,
+      errors: [
+        {
+          messageId: 'missingPropType',
+          data: { name: 'missing' },
         },
       ],
     }


### PR DESCRIPTION
Fixes #3861.

In a function component, `prop-types` counts any `props.*` member access as a use of the component's props, keyed on the name alone. When a nested callback declares its own parameter named `props`, as in the issue's `useQuery(..., { select: props => props.isError ? null : props })`, every property read on that parameter is reported as a missing prop. Renaming the parameter makes the report disappear, which is the reporter's own control. This is a false positive only, nothing worse.

The fix resolves the identifier through scope before counting it. When it resolves to a parameter of a function that is not itself a component (`React.memo` and `forwardRef` wrappers still count) and that function is passed inline as a call argument or a JSX attribute value, the access belongs to the callback and is skipped. Everything else keeps the current behavior: closures over the component's props, nested helpers that shadow `props` and are called with the real thing, and unresolved names all still report. The same guard covers destructuring from such a parameter.

Because this narrows what the rule reports, the risk is a silent false negative, so I leaned on the existing suite. Its baseline has environment failures that depend on the installed typescript (4.9.5 breaks 140 TS-feature cases under the legacy `typescript-eslint` parser, 3.9.10 breaks every `@typescript-eslint/parser` case), so I ran it under both versions. Every case runs under at least one, and no existing case changes state in either. Added 4 valid cases pinning the fix and 3 invalid ones pinning genuine reports, and with the fix reverted the valid ones fail. `no-unused-prop-types` shares this util. Its suite is unchanged, and it now reports a declared prop whose only use was inside a foreign callback, which it previously missed.
